### PR TITLE
Change order of rendering for glob helper

### DIFF
--- a/lib/helpers/helpers-file.js
+++ b/lib/helpers/helpers-file.js
@@ -45,11 +45,10 @@
   Usage: {{{ glob [file] }}
   */
 
-
-  module.exports.glob = glob = function(src) {
+  module.exports.glob = glob = function(src, compare_fn) {
     var content;
 
-    content = Utils.globFiles(src);
+    content = Utils.globFiles(src, compare_fn);
     return Utils.safeString(content);
   };
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -326,10 +326,35 @@
   */
 
 
-  Utils.globFiles = function(src) {
-    var content;
+ /**
+  * @param {String|Array} src Globbing pattern(s).
+  * @param {Function=} compare_fn Function accepting two objects (a,b)
+  *   and returning 1 if a >= b otherwise -1.
+  *
+  * Note: Objects passed to compare_fn are:
+  *   {
+  *     index: original index of file strating with 1
+  *     path: full file path
+  *     content: content of file
+  *   }
+  */
+  Utils.globFiles = function(src, compare_fn) {
+    var content, 
+      compare_fn = compare_fn || function(a,b) { return a.index >= b.index ? 1 : -1}, 
+      index=0;
 
-    return content = grunt.file.expand(src).map(grunt.file.read).join(grunt.util.normalizelf(grunt.util.linefeed));
+    return content = grunt.file.expand(src)      
+      .map(function(path) {
+        index += 1
+        return {
+          index: index,
+          path: path,
+          content:grunt.file.read(path)
+        }
+      })
+      .sort(compare_fn)
+      .map(function(obj){return obj.content})
+      .join(grunt.util.normalizelf(grunt.util.linefeed));
   };
 
   Utils.buildObjectPaths = function(obj) {


### PR DESCRIPTION
Glob helper now takes compare function as 2nd parameter. The function
will be passed two objects and is expected to return 1 if a >= b or
-1 otherwise. IF you want descending sort order, then 1 and -1 should
be reversed.

This compare function can be defined in options passed to assemble:

```
assemble: {
  options: {
    ..
    compare_fn: function(a,b) {return a.index >= b.index ? 1 : -1},
    ..
  }
}
```
