### PR TITLE
withSort does not support descendant properties

### DIFF
--- a/src/helpers/helpers-collections.coffee
+++ b/src/helpers/helpers-collections.coffee
@@ -118,7 +118,13 @@ module.exports.withSort = withSort = (array, field, options) ->
     array = array.sort()
     result += options.fn(item) for item in array
   else
-    array = array.sort (a, b) -> getDescendantProp(a, field) > getDescendantProp(b, field)
+    array = array.sort (a, b) -> 
+      aProp = getDescendantProp(a, field)
+      bProp = getDescendantProp(b, field)
+      if aProp > bProp
+        return 1
+      else return -1  if aProp < bProp
+      0
     result += options.fn(array[item]) for item of array
   result
 


### PR DESCRIPTION
Lets say that I want to list all my pages with a certain tag `Test`. I use the following code snippet to do this:

``` html
{{#each tags}}
{{#is tag "Test"}}
<h1>{{tag}}</h1>
<ul>
  {{#each pages}}
    <li>{{data.title}}</li>
  {{/each}}
</ul>
{{/is}}
{{/each}}
```

If I also want to sort the pages based on their publish date, I'd try to do this:

``` html
{{#each tags}}
{{#is tag "Test"}}
<h1>{{tag}}</h1>
<ul>
  {{#withSort pages "data.date"}}
    <li>{{data.title}}</li>
  {{/withSort}}
</ul>
{{/is}}
{{/each}}
```

This does not work currently because the array is sorted like this: 

```
array = array.sort(function(a, b) {
  return a[field] > b[field];
});
```

and `a[field]` converts to `a['data.title']` and that does not match `a['data']['title']` which is what we wanted.

So I've added this pull request that has a small function for getting the descendant property and using that to get the sorting right. It does have a drawback where you can not have variable names like `a['my.page']` as those will be interpreted as `a.my.page`, but I feel that the problem I've solved here is more common than using variable names with a dot in them.

What do you think?

Oh, btw, I'm not familiar with coffee script (nor do I like it), but since this source code was written with it, I had to use online converter to get this pull request done. So the code might not be pretty. And I have not been able to test if the generated code works at all. (The original javascript code I converted it from, did work.)
