### PR TITLE
fixing markdown helper to use the marked object from the options block

### DIFF
--- a/lib/helper-lib.js
+++ b/lib/helper-lib.js
@@ -9,16 +9,13 @@
 
   module.exports.register = function(Handlebars, options) {
     var endsWith, file, loadFile, _i, _len, _ref, _results;
-
     endsWith = function(str, search) {
       var result;
-
       result = str.indexOf(search, str.length - search.length);
       return result !== -1;
     };
     loadFile = function(file) {
       var helper;
-
       if (!endsWith(file, 'helpers.js')) {
         helper = require(file);
       }

--- a/lib/helpers/helpers-code.js
+++ b/lib/helpers/helpers-code.js
@@ -1,5 +1,4 @@
-/*! special helpers
-*/
+/*! special helpers*/
 
 
 (function() {
@@ -18,7 +17,6 @@
   module.exports = {
     embed: embed = function(src, lang) {
       var content, ext, output, result;
-
       content = Utils.globFiles(src);
       ext = path.extname(src).replace(/^(\.)/gm, '');
       if (Utils.isUndefined(lang)) {
@@ -59,7 +57,6 @@
     },
     jsfiddle: jsfiddle = function(id, tabs) {
       var result;
-
       if (Utils.isUndefined(tabs)) {
         tabs = "result,js,html,css";
       }
@@ -68,7 +65,6 @@
     },
     gist: gist = function(id, file) {
       var result;
-
       id = Handlebars.Utils.escapeExpression(id);
       if (Utils.isUndefined(file)) {
         file = "";

--- a/lib/helpers/helpers-collections.js
+++ b/lib/helpers/helpers-collections.js
@@ -1,5 +1,4 @@
-/*! collection helpers
-*/
+/*! collection helpers*/
 
 
 (function() {
@@ -22,7 +21,6 @@
 
   module.exports.withFirst = withFirst = function(array, count, options) {
     var item, result;
-
     if (Utils.isUndefined(count)) {
       options = count;
       return options.fn(array[0]);
@@ -46,7 +44,6 @@
 
   module.exports.withLast = withLast = function(array, count, options) {
     var item, result;
-
     if (Utils.isUndefined(count)) {
       options = count;
       return options.fn(array[array.length - 1]);
@@ -66,7 +63,6 @@
 
   module.exports.withAfter = withAfter = function(array, count, options) {
     var item, result;
-
     array = array.slice(count);
     result = '';
     for (item in array) {
@@ -81,7 +77,6 @@
 
   module.exports.withBefore = withBefore = function(array, count, options) {
     var item, result;
-
     array = array.slice(0, -count);
     result = '';
     for (item in array) {
@@ -96,7 +91,6 @@
 
   module.exports.joinAny = joinAny = function(items, block) {
     var delimiter, end, i, len, out, start;
-
     delimiter = block.hash.delimiter || ",";
     start = start = block.hash.start || 0;
     len = (items ? items.length : 0);
@@ -136,7 +130,6 @@
 
   module.exports.withSort = withSort = function(array, field, options) {
     var item, result, _i, _len;
-
     result = '';
     if (Utils.isUndefined(field)) {
       options = field;
@@ -201,7 +194,6 @@
 
   module.exports.iterate = iterate = function(context, options) {
     var data, fn, i, inverse, j, key, ret;
-
     fn = options.fn;
     inverse = options.inverse;
     i = 0;
@@ -244,7 +236,6 @@
 
   module.exports.forEach = forEach = function(array, fn) {
     var buffer, i, item, j, total;
-
     total = array.length;
     buffer = "";
     i = 0;
@@ -263,7 +254,6 @@
 
   module.exports.eachWithClasses = eachWithClasses = function(array, fn) {
     var buffer, i, item, j;
-
     buffer = "";
     i = 0;
     j = array.length;
@@ -286,7 +276,6 @@
 
   module.exports.eachIndex = eachIndex = function(array, options) {
     var index, result, value, _i, _len;
-
     result = '';
     for (index = _i = 0, _len = array.length; _i < _len; index = ++_i) {
       value = array[index];
@@ -300,7 +289,6 @@
 
   module.exports.arrayify = arrayify = function(data) {
     var result;
-
     result = data.split(",").map(function(tag) {
       return "\"" + tag + "\"";
     });

--- a/lib/helpers/helpers-comparisons.js
+++ b/lib/helpers/helpers-comparisons.js
@@ -1,5 +1,4 @@
-/*! comparison helpers
-*/
+/*! comparison helpers*/
 
 
 (function() {
@@ -141,7 +140,6 @@
 
   module.exports.ifAny = ifAny = function() {
     var argLength, content, i, success;
-
     argLength = arguments.length - 2;
     content = arguments[argLength + 1];
     success = true;

--- a/lib/helpers/helpers-data.js
+++ b/lib/helpers/helpers-data.js
@@ -1,5 +1,4 @@
-/*! object helpers
-*/
+/*! object helpers*/
 
 
 (function() {

--- a/lib/helpers/helpers-dates.js
+++ b/lib/helpers/helpers-dates.js
@@ -1,5 +1,4 @@
-/*! date helpers
-*/
+/*! date helpers*/
 
 
 (function() {
@@ -16,7 +15,6 @@
 
   module.exports.now = now = function(format) {
     var date;
-
     date = new Date();
     if (Utils.isUndefined(format)) {
       return date;
@@ -27,7 +25,6 @@
 
   module.exports.timeago = timeago = function(date) {
     var interval, seconds;
-
     date = new Date(date);
     seconds = Math.floor((new Date() - date) / 1000);
     interval = Math.floor(seconds / 31536000);

--- a/lib/helpers/helpers-html.js
+++ b/lib/helpers/helpers-html.js
@@ -1,11 +1,9 @@
-/*! html helpers
-*/
+/*! html helpers*/
 
 
 (function() {
   module.exports.register = function(Handlebars, options) {
     var HTML, Utils, grunt, util, _;
-
     grunt = require('grunt');
     util = require('util');
     Utils = require('../utils/utils');
@@ -17,7 +15,6 @@
       }
       return Utils.safeString(context.map(function(item) {
         var css, ext, less;
-
         ext = Utils.getExt(item);
         css = '<link rel="stylesheet" href="' + options.assets + '/css/' + item + '">';
         less = '<link rel="stylesheet/less" href="' + options.assets + '/less/' + item + '">';
@@ -37,7 +34,6 @@
       }
       return Utils.safeString(context.map(function(item) {
         var coffee, ext, js;
-
         ext = Utils.getExt(item);
         js = '<script src="' + options.assets + '/js/' + item + '"></script>';
         coffee = '<script type="text/coffeescript" src="' + options.assets + '/js/' + item + '"></script>';

--- a/lib/helpers/helpers-inflections.js
+++ b/lib/helpers/helpers-inflections.js
@@ -1,5 +1,4 @@
-/*! inflection helpers
-*/
+/*! inflection helpers*/
 
 
 (function() {
@@ -10,7 +9,6 @@
 
   module.exports.inflect = inflect = function(count, singular, plural, include) {
     var word;
-
     word = count > 1 || count === 0 ? plural : singular;
     if (Utils.isUndefined(include) || include === false) {
       return word;
@@ -21,7 +19,6 @@
 
   module.exports.ordinalize = ordinalize = function(value) {
     var normal, _ref;
-
     normal = Math.abs(Math.round(value));
     if (_ref = normal % 100, __indexOf.call([11, 12, 13], _ref) >= 0) {
       return "" + value + "th";

--- a/lib/helpers/helpers-logging.js
+++ b/lib/helpers/helpers-logging.js
@@ -1,5 +1,4 @@
-/*! logging helpers
-*/
+/*! logging helpers*/
 
 
 (function() {
@@ -23,7 +22,6 @@
 
   module.exports.expandJSON = expandJSON = function(src) {
     var json, list;
-
     list = grunt.file.expand(src);
     json = JSON.stringify(list, null, 2);
     return Utils.safeString(json);
@@ -31,7 +29,6 @@
 
   module.exports.expandMapping = expandMapping = function(src) {
     var list, yml;
-
     list = Utils.expandMapping(src);
     yml = to.format.yaml.stringify(list);
     return Utils.safeString(yml);
@@ -39,7 +36,6 @@
 
   module.exports.expandYAML = expandYAML = function(src) {
     var list, yml;
-
     list = grunt.file.expand(src);
     yml = to.format.yaml.stringify(list);
     return Utils.safeString(yml);
@@ -57,7 +53,6 @@
     Handlebars.registerHelper("log", log);
     Handlebars.registerHelper("inspect", function(obj, ext) {
       var html, md, result;
-
       if (Utils.isUndefined(options.ext)) {
         ext = ".html";
       } else {

--- a/lib/helpers/helpers-markdown.js
+++ b/lib/helpers/helpers-markdown.js
@@ -1,5 +1,4 @@
-/*! markdown helpers
-*/
+/*! markdown helpers*/
 
 
 (function() {
@@ -13,7 +12,6 @@
 
   module.exports.register = function(Handlebars, options) {
     var Markdown, Utils, hljs, isServer, opts;
-
     Utils = require('../utils/utils');
     hljs = require('highlight.js');
     opts = {
@@ -27,7 +25,6 @@
       langPrefix: "lang-",
       highlight: function(code, lang) {
         var res;
-
         res = void 0;
         if (!lang) {
           return code;
@@ -43,19 +40,17 @@
         }
       }
     };
-    opts = _.extend(opts, options);
+    opts = _.extend(opts, options.marked);
     isServer = typeof process !== 'undefined';
     Markdown = require('../utils/markdown').Markdown(opts);
     Handlebars.registerHelper("markdown", function(options) {
       var content;
-
       content = options.fn(this);
       return Markdown.convert(content);
     });
     if (isServer) {
       Handlebars.registerHelper("md", function(path) {
         var content, html, md, tmpl;
-
         content = Utils.globFiles(path);
         tmpl = Handlebars.compile(content);
         md = tmpl(this);

--- a/lib/helpers/helpers-math.js
+++ b/lib/helpers/helpers-math.js
@@ -1,5 +1,4 @@
-/*! math helpers
-*/
+/*! math helpers*/
 
 
 (function() {
@@ -37,7 +36,6 @@
 
   module.exports.sum = sum = function() {
     var args, i;
-
     args = _.flatten(arguments);
     sum = 0;
     i = args.length - 1;

--- a/lib/helpers/helpers-miscellaneous.js
+++ b/lib/helpers/helpers-miscellaneous.js
@@ -1,5 +1,4 @@
-/*! miscellaneous helpers
-*/
+/*! miscellaneous helpers*/
 
 
 (function() {

--- a/lib/helpers/helpers-numbers.js
+++ b/lib/helpers/helpers-numbers.js
@@ -1,5 +1,4 @@
-/*! number helpers
-*/
+/*! number helpers*/
 
 
 (function() {
@@ -38,7 +37,6 @@
 
   module.exports.toAbbr = toAbbr = function(number, digits) {
     var abbr, i, size;
-
     if (Utils.isUndefined(digits)) {
       digits = 2;
     }

--- a/lib/helpers/helpers-path.js
+++ b/lib/helpers/helpers-path.js
@@ -1,5 +1,4 @@
-/*! path helpers
-*/
+/*! path helpers*/
 
 
 (function() {

--- a/lib/helpers/helpers-strings.js
+++ b/lib/helpers/helpers-strings.js
@@ -1,5 +1,4 @@
-/*! string helpers
-*/
+/*! string helpers*/
 
 
 (function() {
@@ -19,7 +18,6 @@
 
   module.exports.center = center = function(str, spaces) {
     var i, space;
-
     space = '';
     i = 0;
     while (i < spaces) {
@@ -58,7 +56,6 @@
 
   module.exports.titleize = titleize = function(str) {
     var capitalize, title, word, words;
-
     title = str.replace(/[ \-_]+/g, ' ');
     words = title.match(/\w+/g);
     capitalize = function(word) {
@@ -66,7 +63,6 @@
     };
     return ((function() {
       var _i, _len, _results;
-
       _results = [];
       for (_i = 0, _len = words.length; _i < _len; _i++) {
         word = words[_i];
@@ -86,7 +82,6 @@
 
   module.exports.occurrences = occurrences = function(string, substring) {
     var l, n, pos;
-
     n = 0;
     pos = 0;
     l = substring.length;
@@ -108,7 +103,6 @@
 
   module.exports.ellipsis = ellipsis = function(text, length) {
     var textStripped;
-
     textStripped = text.replace(/(<([^>]+)>)/g, "");
     if (textStripped.length < length) {
       return textStripped;

--- a/lib/helpers/helpers-url.js
+++ b/lib/helpers/helpers-url.js
@@ -1,5 +1,4 @@
-/*! URL helpers
-*/
+/*! URL helpers*/
 
 
 (function() {
@@ -27,7 +26,6 @@
 
   module.exports.url_parse = url_parse = function(uri, type, query) {
     var result;
-
     uri = url.parse(uri);
     result = Utils.stringifyObj(uri, type, query);
     return Utils.safeString(result);

--- a/lib/utils/dates.js
+++ b/lib/utils/dates.js
@@ -5,7 +5,6 @@
 
   Dates.padNumber = function(num, count, padCharacter) {
     var lenDiff, padding;
-
     if (typeof padCharacter === 'undefined') {
       padCharacter = '0';
     }
@@ -21,21 +20,18 @@
 
   Dates.dayOfYear = function(date) {
     var oneJan;
-
     oneJan = new Date(date.getFullYear(), 0, 1);
     return Math.ceil((date - oneJan) / 86400000);
   };
 
   Dates.weekOfYear = function(date) {
     var oneJan;
-
     oneJan = new Date(date.getFullYear(), 0, 1);
     return Math.ceil((((date - oneJan) / 86400000) + oneJan.getDay() + 1) / 7);
   };
 
   Dates.isoWeekOfYear = function(date) {
     var dayDiff, dayNr, jan4, target;
-
     target = new Date(date.valueOf());
     dayNr = (date.getDay() + 6) % 7;
     target.setDate(target.getDate() - dayNr + 3);
@@ -54,7 +50,6 @@
 
   Dates.timeZoneOffset = function(date) {
     var hoursDiff, result;
-
     hoursDiff = -date.getTimezoneOffset() / 60;
     result = Dates.padNumber(Math.abs(hoursDiff), 4);
     return (hoursDiff > 0 ? '+' : '-') + result;
@@ -62,7 +57,6 @@
 
   Dates.format = function(date, format) {
     var match;
-
     match = null;
     return format.replace(Dates.formats, function(m, p) {
       switch (p) {

--- a/lib/utils/markdown.js
+++ b/lib/utils/markdown.js
@@ -21,7 +21,6 @@
 
   Markdown.prototype.init = function(options) {
     var defaults;
-
     defaults = {
       fromFile: true
     };
@@ -31,7 +30,6 @@
 
   Markdown.prototype.read = function(src) {
     var md;
-
     if (!fs.existsSync(src)) {
       console.log("File " + src + " not found.");
       return "";
@@ -42,7 +40,6 @@
 
   Markdown.prototype.convert = function(src) {
     var codeLines, html, shouldWrap, wrapLines;
-
     codeLines = this.options.codeLines;
     shouldWrap = false;
     if (codeLines && codeLines.before && codeLines.after) {
@@ -50,7 +47,6 @@
     }
     wrapLines = function(code) {
       var after, before, out;
-
       out = [];
       before = codeLines.before;
       after = codeLines.after;
@@ -64,7 +60,6 @@
       if (this.options.highlight === "auto") {
         this.options.highlight = function(code) {
           var out;
-
           out = hljs.highlightAuto(code).value;
           if (shouldWrap) {
             out = wrapLines(out);
@@ -74,7 +69,6 @@
       } else if (this.options.highlight === "manual") {
         this.options.highlight = function(code, lang) {
           var e, out;
-
           out = code;
           try {
             code = hljs.highlight(lang, code).value;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -25,7 +25,6 @@
 
   Utils.isBoolean = function(obj) {
     var type, undef;
-
     undef = void 0;
     type = typeof obj;
     return obj !== undef && type === "boolean" || type === "Boolean";
@@ -33,21 +32,18 @@
 
   Utils.isNumber = function(obj) {
     var undef;
-
     undef = void 0;
     return obj !== undef && obj !== null && (typeof obj === "number" || obj instanceof Number);
   };
 
   Utils.isObject = function(obj) {
     var undef;
-
     undef = void 0;
     return obj !== null && obj !== undef && typeof obj === "object";
   };
 
   Utils.isRegExp = function(obj) {
     var undef;
-
     undef = void 0;
     return obj !== undef && obj !== null && (obj instanceof RegExp);
   };
@@ -89,7 +85,6 @@
 
   Utils.trim = function(str) {
     var trim;
-
     trim = /\S/.test("\xA0") ? /^[\s\xA0]+|[\s\xA0]+$/g : /^\s+|\s+$/g;
     return str.toString().replace(trim, '');
   };
@@ -114,14 +109,12 @@
 
   Utils.stringifyYAML = function(src) {
     var YAML, stringifyFile;
-
     YAML = to.format.yaml;
     return stringifyFile = YAML.stringify(src);
   };
 
   Utils.stringifyObj = function(src, type) {
     var YAML, output;
-
     YAML = to.format.yaml;
     output = JSON.stringify(src, null, 2);
     switch (type) {
@@ -148,7 +141,6 @@
 
   Utils.showProps = function(obj, objName) {
     var i, result;
-
     result = "";
     for (i in obj) {
       if (obj.hasOwnProperty(i)) {
@@ -160,7 +152,6 @@
 
   Utils.listAllProperties = function(obj) {
     var objectToInspect, result;
-
     objectToInspect = void 0;
     result = [];
     objectToInspect = obj;
@@ -173,7 +164,6 @@
 
   Utils.listProps = function(obj) {
     var key, result, value;
-
     key = void 0;
     value = void 0;
     result = [];
@@ -196,7 +186,6 @@
 
   Utils.getExt = function(str) {
     var extname;
-
     extname = path.extname(str);
     if (extname) {
       str = extname;
@@ -209,14 +198,12 @@
 
   Utils.getBasename = function(base, ext) {
     var fullName;
-
     fullName = path.basename(base, ext);
     return base = path.basename(base, path.extname(fullName));
   };
 
   Utils.getRelativePath = function(from, to) {
     var fromDirname, relativePath, toBasename, toDirname;
-
     fromDirname = path.normalize(path.dirname(from));
     toDirname = path.normalize(path.dirname(to));
     toBasename = path.basename(to);
@@ -231,7 +218,6 @@
 
   Utils.toggleOutput = function(ext, md, html) {
     var output;
-
     if (ext === '') {
       return output = md;
     } else {
@@ -241,7 +227,6 @@
 
   Utils.switchOutput = function(ext, md, html) {
     var output;
-
     switch (ext) {
       case "":
       case ".md":
@@ -256,7 +241,6 @@
 
   Utils.switchType = function(ext) {
     var reader;
-
     reader = grunt.file.readJSON;
     Utils.getExt(ext);
     switch (ext) {
@@ -272,7 +256,6 @@
 
   Utils.readOptionalJSON = function(filepath) {
     var data;
-
     data = {};
     try {
       data = grunt.file.readJSON(filepath);
@@ -283,7 +266,6 @@
 
   Utils.readOptionalYAML = function(filepath) {
     var data;
-
     data = {};
     try {
       data = grunt.file.readYAML(filepath);
@@ -294,7 +276,6 @@
 
   Utils.readPackageJSON = function(filepath) {
     var data;
-
     data = {};
     try {
       data = grunt.file.readJSON(filepath);
@@ -308,7 +289,6 @@
 
   Utils.repoUrl = function(str) {
     var pkg, url;
-
     pkg = grunt.file.readJSON("./package.json");
     url = pkg.repository.url;
     return str = url.replace(/.*:\/\/github.com\/(.*?)(?:\.git|$)/, str);
@@ -316,7 +296,6 @@
 
   Utils.detectIndentation = function(string) {
     var i, il, indentation, prevalent, spaces, tabs;
-
     tabs = string.match(/^[\t]+/g) || [];
     spaces = string.match(/^[ ]+/g) || [];
     prevalent = (tabs.length >= spaces.length ? tabs : spaces);
@@ -347,50 +326,42 @@
 
   Utils.exists = function(file) {
     var src;
-
     return src = grunt.file.exists(file);
   };
 
   Utils.read = function(filepath, options) {
     var src;
-
     return src = grunt.file.read(filepath, options);
   };
 
   Utils.readJSON = function(filepath, options) {
     var src;
-
     return src = grunt.file.readJSON(filepath, options);
   };
 
   Utils.readYAML = function(filepath, options) {
     var src;
-
     return src = grunt.file.readYAML(filepath, options);
   };
 
   Utils.write = function(filepath, contents, options) {
     var src;
-
     return src = grunt.file.write(filepath, contents, options);
   };
 
   Utils.copyFile = function(filepath, options) {
     var src;
-
     src = grunt.file.copy(filepath, options);
     return true;
   };
 
   Utils.mkDir = function(dirpath, mode) {
     var src;
-
     return src = grunt.file.mdDir(dirpath, mode);
   };
 
   Utils.normalizelf = function(str) {
     var src;
-
     return src = grunt.util.normalizelf(str);
   };
 
@@ -401,7 +372,6 @@
 
   Utils.globFiles = function(src, compare_fn) {
     var content, index;
-
     content = void 0;
     compare_fn = compare_fn || function(a, b) {
       if (a.index >= b.index) {
@@ -425,11 +395,9 @@
 
   Utils.buildObjectPaths = function(obj) {
     var files;
-
     files = [];
     _.forOwn(obj, function(value, key) {
       var file, recurse;
-
       file = key;
       recurse = function(obj) {
         return _.forOwn(obj, function(value, key) {
@@ -452,13 +420,11 @@
 
   Utils.globObject = function(obj, pattern) {
     var files, getValue, matches, rtn, setValue;
-
     files = Utils.buildObjectPaths(obj);
     matches = files.filter(minimatch.filter(pattern));
     rtn = {};
     getValue = function(obj, path) {
       var keys, value;
-
       keys = path.split('/');
       value = _.cloneDeep(obj);
       _.forEach(keys, function(key) {
@@ -470,7 +436,6 @@
     };
     setValue = function(obj, path, value) {
       var key, keys;
-
       keys = path.split('/');
       key = keys.shift();
       if (keys.length) {
@@ -482,7 +447,6 @@
     };
     _.forEach(matches, function(match) {
       var value;
-
       value = getValue(obj, match);
       return rtn = setValue(rtn, match, value);
     });
@@ -496,7 +460,6 @@
 
   Utils.getMatches = function(string, regex, index) {
     var match, matches;
-
     index || (index = 1);
     matches = [];
     match = void 0;
@@ -508,12 +471,10 @@
 
   RegExp.prototype.execAll = function(string) {
     var group, match, matches;
-
     matches = [];
     while (match = this.exec(string)) {
       matches.push((function() {
         var _i, _len, _results;
-
         _results = [];
         for (_i = 0, _len = match.length; _i < _len; _i++) {
           group = match[_i];

--- a/src/helpers/helpers-markdown.coffee
+++ b/src/helpers/helpers-markdown.coffee
@@ -30,11 +30,11 @@ module.exports.register = (Handlebars, options) ->
       finally
         return res or code
   )
-  opts     = _.extend opts, options
+  opts     = _.extend opts, options.marked
   isServer = (typeof process isnt 'undefined')
 
   Markdown = require('../utils/markdown').Markdown opts
-  
+
   # Markdown: markdown helper enables writing markdown inside HTML
   # and then renders the markdown as HTML inline with the rest of the page.
   # Usage: {{#markdown}} # This is a title. {{/markdown}}

--- a/src/tests/helpers/markdown_test.coffee
+++ b/src/tests/helpers/markdown_test.coffee
@@ -2,7 +2,9 @@ require "should"
 path = require("path")
 grunt = require("grunt")
 Handlebars = require("handlebars")
-require("../../lib/helpers/helpers-markdown").register Handlebars, gfm: true
+require("../../lib/helpers/helpers-markdown").register Handlebars, 
+  marked:
+    gfm: true
 
 pkg = grunt.file.readJSON('package.json')
 
@@ -24,4 +26,17 @@ describe "markdown", ->
         template = Handlebars.compile(source)
         template(filename: filename).should.equal simpleExpected
         done()
+
+describe "markdown options", ->
+  it "langPrefix", (done) ->
+    require("../../lib/helpers/helpers-markdown").register Handlebars, 
+      marked:
+        gfm: true
+        langPrefix: 'language-'
+
+    codeExample = "{{#markdown}}\n## Some Markdown\n\n```js\nvar foo='bar';\n```{{/markdown}}"
+    codeExampleExpected = "<h2>Some Markdown</h2>\n<pre><code class=\"language-js\"><span class=\"keyword\">var</span> foo=<span class=\"string\">'bar'</span>;</code></pre>\n"
+    template = Handlebars.compile(codeExample)
+    template().should.equal codeExampleExpected
+    done()
 

--- a/test/helpers/code_test.js
+++ b/test/helpers/code_test.js
@@ -15,7 +15,6 @@
     describe('{{jsfiddle id}}', function() {
       return it('should return a jsfiddle embed link, with default tabs assigned', function() {
         var source, template;
-
         source = '{{jsfiddle "UXbas"}}';
         template = Handlebars.compile(source);
         return template().should.equal('<iframe width="100%" height="300" src="http://jsfiddle.net/UXbas/embedded/result,js,html,css/presentation/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>');
@@ -24,7 +23,6 @@
     return describe('{{jsfiddle id tabs}}', function() {
       return it('should return a jsfiddle embed link, with custom tabs assigned', function() {
         var source, template;
-
         source = '{{jsfiddle "UXbas" "html,css"}}';
         template = Handlebars.compile(source);
         return template().should.equal('<iframe width="100%" height="300" src="http://jsfiddle.net/UXbas/embedded/html,css/presentation/" allowfullscreen="allowfullscreen" frameborder="0"></iframe>');
@@ -36,7 +34,6 @@
     return describe('{{gist id}}', function() {
       return it('should return a gist script tag', function() {
         var source, template;
-
         source = '{{gist "abcdefg"}}';
         template = Handlebars.compile(source);
         return template().should.equal('<script src="https://gist.github.com/abcdefg.js"></script>');

--- a/test/helpers/collections_test.js
+++ b/test/helpers/collections_test.js
@@ -15,7 +15,6 @@
     describe('{{first collection}}', function() {
       return it('should return the first item in a collection.', function() {
         var source, template;
-
         source = '{{first collection}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('Amy Wong');
@@ -24,7 +23,6 @@
     return describe('{{first collection 2}}', function() {
       return it('should return an array with the first two items in a collection.', function() {
         var source, template;
-
         source = '{{first collection 2}}';
         template = Handlebars.compile(source);
         return template(context).should.eql(['Amy Wong', 'Bender']);
@@ -38,7 +36,6 @@
   {{/withFirst}}', function() {
       return it('should use the first item in a collection inside a block.', function() {
         var source, template;
-
         source = '{{#withFirst collection}}<p>{{this}} is smart.</p>{{/withFirst}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<p>Amy Wong is smart.</p>');
@@ -49,7 +46,6 @@
   {{/withFirst}}', function() {
       return it('should use the first two items in a collection inside a block.', function() {
         var source, template;
-
         source = '{{#withFirst collection 2}}<p>{{this}} is smart.</p>{{/withFirst}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<p>Amy Wong is smart.</p><p>Bender is smart.</p>');
@@ -61,7 +57,6 @@
     describe('{{last collection}}', function() {
       return it('should return the last item in a collection.', function() {
         var source, template;
-
         source = '{{last collection}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('Scruffy');
@@ -70,7 +65,6 @@
     return describe('{{last collection 2}}', function() {
       return it('should return an array with the last two items in a collection.', function() {
         var source, template;
-
         source = '{{last collection 2}}';
         template = Handlebars.compile(source);
         return template(context).should.eql(['Professor Farnsworth', 'Scruffy']);
@@ -84,7 +78,6 @@
   {{/withLast}}', function() {
       return it('should use the last item in a collection inside a block.', function() {
         var source, template;
-
         source = '{{#withLast collection}}<p>{{this}} is dumb.</p>{{/withLast}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<p>Scruffy is dumb.</p>');
@@ -95,7 +88,6 @@
   {{/withLast}}', function() {
       return it('should use the last two items in a collection inside a block.', function() {
         var source, template;
-
         source = '{{#withLast collection 2}}<p>{{this}} is dumb.</p>{{/withLast}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<p>Professor Farnsworth is dumb.</p><p>Scruffy is dumb.</p>');
@@ -107,7 +99,6 @@
     return describe('{{after collection 5}}', function() {
       return it('should return all of the items in a collection after the specified count.', function() {
         var source, template;
-
         source = '{{after collection 5}}';
         template = Handlebars.compile(source);
         return template(context).should.eql(['Leela', 'Professor Farnsworth', 'Scruffy']);
@@ -121,7 +112,6 @@
   {{/withAfter}}', function() {
       return it('should use all of the items in a collection after the specified count inside a block.', function() {
         var source, template;
-
         source = '{{#withAfter collection 5}}<{{this}}>{{/withAfter}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<Leela><Professor Farnsworth><Scruffy>');
@@ -133,7 +123,6 @@
     return describe('{{before collection 5}}', function() {
       return it('should return all of the items in a collection before the specified count.', function() {
         var source, template;
-
         source = '{{before collection 5}}';
         template = Handlebars.compile(source);
         return template(context).should.eql(['Amy Wong', 'Bender', 'Dr. Zoidberg']);
@@ -147,7 +136,6 @@
   {{/withBefore}}', function() {
       return it('should use all of the items in a collection before the specified count inside a block.', function() {
         var source, template;
-
         source = '{{#withBefore collection 5}}<{{this}}>{{/withBefore}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<Amy Wong><Bender><Dr. Zoidberg>');
@@ -159,7 +147,6 @@
     return describe('{{join collection " | "}}', function() {
       return it('should return all items in a collection joined by a separator if specified.', function() {
         var source, template;
-
         source = '{{join collection " | "}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('Amy Wong | Bender | Dr. Zoidberg | Fry | Hermes Conrad | Leela | Professor Farnsworth | Scruffy');
@@ -171,7 +158,6 @@
     describe('{{sort collection}}', function() {
       return it('should return all items in a collection sorted in lexicographical order.', function() {
         var source, template;
-
         source = '{{sort collection}}';
         template = Handlebars.compile(source);
         return template(context).should.eql(['Amy Wong', 'Bender', 'Dr. Zoidberg', 'Fry', 'Hermes Conrad', 'Leela', 'Professor Farnsworth', 'Scruffy']);
@@ -180,7 +166,6 @@
     return describe('{{sort collection "name"}}', function() {
       return it('should return all items in a collection sorted in by name.', function() {
         var source, template, _context;
-
         source = '{{sort collection "name"}}';
         template = Handlebars.compile(source);
         _context = {
@@ -219,7 +204,6 @@
   {{/withSort}}', function() {
       return it('should sort the collection in lexicographical order and use it in a block.', function() {
         var source, template;
-
         source = '{{#withSort collection}}<p>{{this}}</p>{{/withSort}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('<p>Amy Wong</p><p>Bender</p><p>Dr. Zoidberg</p><p>Fry</p><p>Hermes Conrad</p><p>Leela</p><p>Professor Farnsworth</p><p>Scruffy</p>');
@@ -230,7 +214,6 @@
   {{/withSort}}', function() {
       return it('should sort the collection by deliveries and use it in a block.', function() {
         var source, template, _context;
-
         source = '{{#withSort collection "deliveries"}}{{name}}: {{deliveries}} <br>{{/withSort}}';
         template = Handlebars.compile(source);
         _context = {
@@ -256,7 +239,6 @@
     return describe('{{length collection}}', function() {
       return it('should return the length of the collection', function() {
         var source, template;
-
         source = '{{length collection}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(8);
@@ -272,7 +254,6 @@
   {{/lengthEqual}}', function() {
       return it('should conditionally render a block based on the length of a collection.', function() {
         var source, template;
-
         source = '{{#lengthEqual collection 3}}There are 3 people in Planet Express.{{else}}This is not Planet Express.{{/lengthEqual}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('This is not Planet Express.');
@@ -288,7 +269,6 @@
   {{/empty}}', function() {
       return it('should conditionally render a block the collection is empty.', function() {
         var source, template;
-
         source = '{{#empty collection}}Bad news everyone!{{else}}Good news everyone!{{/empty}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('Good news everyone!');
@@ -304,7 +284,6 @@
   {{/any}}', function() {
       return it('should conditionally render a block the collection isn\'t empty.', function() {
         var source, template;
-
         source = '{{#any collection}}Bad news everyone!{{else}}Good news everyone!{{/any}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('Bad news everyone!');
@@ -320,7 +299,6 @@
   {{/inArray}}', function() {
       return it('should conditionally render a block if a specified value is in the collection.', function() {
         var source, template;
-
         source = '{{#inArray collection "Fry"}}I\'m walking on sunshine!{{else}}I\'m walking in darkness.{{/inArray}}';
         template = Handlebars.compile(source);
         return template(context).should.equal('I\'m walking on sunshine!');
@@ -334,7 +312,6 @@
   {{/eachIndex}}', function() {
       return it('should render the block using the array and each item\'s index.', function() {
         var source, template;
-
         source = '{{#eachIndex collection}} {{item}} is {{index}} {{/eachIndex}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(' Amy Wong is 0  Bender is 1  Dr. Zoidberg is 2  Fry is 3  Hermes Conrad is 4  Leela is 5  Professor Farnsworth is 6  Scruffy is 7 ');
@@ -346,7 +323,6 @@
     return describe('{{#each collection}} {{@key}}: {{this}} {{/each}}', function() {
       return it('should use the key and value of each property in an object inside a block.', function() {
         var source, template;
-
         context = {
           collection: {
             fry: 3,

--- a/test/helpers/comparisons_test.js
+++ b/test/helpers/comparisons_test.js
@@ -15,7 +15,6 @@
   {{/is}}', function() {
       return it('should render a block if the condition is true.', function() {
         var context, source, template;
-
         source = '{{#is bender "great"}}Kiss my shiny metal ass!{{else}}Never mind :({{/is}}';
         template = Handlebars.compile(source);
         context = {
@@ -34,7 +33,6 @@
   {{/isnt}}', function() {
       return it('should render a block if the condition is not true.', function() {
         var context, source, template;
-
         source = '{{#isnt number 2}}Kiss my great metal ass!{{else}}Never mind :({{/isnt}}';
         template = Handlebars.compile(source);
         context = {
@@ -53,7 +51,6 @@
   {{/gt}}', function() {
       return it('should render a block if the value is greater than a given number.', function() {
         var context, source, template;
-
         source = '{{#gt number 8}}Kiss my glorious metal ass!{{else}}Never mind :({{/gt}}';
         template = Handlebars.compile(source);
         context = {
@@ -72,7 +69,6 @@
   {{/gte}}', function() {
       return it('should render a block if the value is greater or equal than a given number.', function() {
         var context, source, template;
-
         source = '{{#gte number 8}}Kiss my perfect metal ass!{{else}}Never mind :({{/gte}}';
         template = Handlebars.compile(source);
         context = {
@@ -91,7 +87,6 @@
   {{/lt}}', function() {
       return it('should render a block if the value is less than a given number.', function() {
         var context, source, template;
-
         source = '{{#lt number 8}}Kiss my golden metal ass!{{else}}Never mind :({{/lt}}';
         template = Handlebars.compile(source);
         context = {
@@ -110,7 +105,6 @@
   {{/lte}}', function() {
       return it('should render a block if the value is less or equal than a given number.', function() {
         var context, source, template;
-
         source = '{{#lte number 8}}Kiss my big metal ass!{{else}}Never mind :({{/lte}}';
         template = Handlebars.compile(source);
         context = {
@@ -129,7 +123,6 @@
   {{/or}}', function() {
       return it('should render a block if one of the values is truthy.', function() {
         var context, source, template;
-
         source = '{{#or great magnificent}}Kiss my perfect metal ass!{{else}}Never mind :({{/or}}';
         template = Handlebars.compile(source);
         context = {
@@ -149,7 +142,6 @@
   {{/and}}', function() {
       return it('should render a block if both values are truthy.', function() {
         var context, source, template;
-
         source = '{{#and great magnificent}}Kiss my glorious metal ass!{{else}}Never mind :({{/and}}';
         template = Handlebars.compile(source);
         context = {

--- a/test/helpers/dates_test.js
+++ b/test/helpers/dates_test.js
@@ -11,7 +11,6 @@
     return describe('{{formatDate date format}}', function() {
       return it('should return the date formated into a string given a specified format.', function() {
         var context, source, template;
-
         source = '{{formatDate date "%F"}}';
         template = Handlebars.compile(source);
         context = {
@@ -26,7 +25,6 @@
     return describe('{{now}}', function() {
       return it('should return the current date.', function() {
         var date, source, template;
-
         date = new Date().getTime();
         source = '{{now}}';
         template = Handlebars.compile(source);
@@ -39,7 +37,6 @@
     return describe('{{timeago date}}', function() {
       return it('should return a human-readable time phrase from the given a date', function() {
         var context, source, template;
-
         source = '{{timeago date}}';
         template = Handlebars.compile(source);
         context = {

--- a/test/helpers/inflections_test.js
+++ b/test/helpers/inflections_test.js
@@ -11,7 +11,6 @@
     describe('{{inflect enemies "enemy" "enemies"}}', function() {
       return it('should return the plural or singular form of a word based on a value.', function() {
         var context, source, template;
-
         source = '{{inflect enemies "enemy" "enemies"}}';
         template = Handlebars.compile(source);
         context = {
@@ -23,7 +22,6 @@
     return describe('{{inflect friends "friend" "friends" true}}', function() {
       return it('should return the plural or singular form of a word based on a value and include the count.', function() {
         var context, source, template;
-
         source = '{{inflect friends "friend" "friends" true}}';
         template = Handlebars.compile(source);
         context = {
@@ -38,7 +36,6 @@
     return describe('{{ordinalize 22}}', function() {
       return it('should return the number converted into an ordinal string.', function() {
         var source, template;
-
         source = '{{ordinalize 22}}';
         template = Handlebars.compile(source);
         return template().should.equal('22nd');

--- a/test/helpers/logging_test.js
+++ b/test/helpers/logging_test.js
@@ -20,7 +20,6 @@
     return describe('{{log "Log helper worked!"}}', function() {
       return it('should log a message to the console.', function() {
         var source, template;
-
         source = '{{log "Log helper worked!"}}';
         template = Handlebars.compile(source);
         template();
@@ -35,7 +34,6 @@
     return describe('{{debug value}}', function() {
       return it('should log current context.', function() {
         var context, source, template;
-
         source = '{{debug this}}';
         template = Handlebars.compile(source);
         context = 'assemble';

--- a/test/helpers/markdown_test.js
+++ b/test/helpers/markdown_test.js
@@ -10,7 +10,9 @@
   Handlebars = require("handlebars");
 
   require("../../lib/helpers/helpers-markdown").register(Handlebars, {
-    gfm: true
+    marked: {
+      gfm: true
+    }
   });
 
   pkg = grunt.file.readJSON('package.json');
@@ -23,7 +25,6 @@
     describe("should convert a block of markdown to HTML", function() {
       return it("{{#markdown}}", function(done) {
         var template;
-
         template = Handlebars.compile(simple);
         template().should.equal(simpleExpected);
         return done();
@@ -33,7 +34,6 @@
       return describe("should convert an imported markdown file to HTML", function() {
         return it("{{md simple1.md}}", function(done) {
           var filename, source, template;
-
           filename = path.join(__dirname, "../files/simple1.md");
           source = "{{md filename}}";
           template = Handlebars.compile(source);
@@ -43,6 +43,23 @@
           return done();
         });
       });
+    });
+  });
+
+  describe("markdown options", function() {
+    return it("langPrefix", function(done) {
+      var codeExample, codeExampleExpected, template;
+      require("../../lib/helpers/helpers-markdown").register(Handlebars, {
+        marked: {
+          gfm: true,
+          langPrefix: 'language-'
+        }
+      });
+      codeExample = "{{#markdown}}\n## Some Markdown\n\n```js\nvar foo='bar';\n```{{/markdown}}";
+      codeExampleExpected = "<h2>Some Markdown</h2>\n<pre><code class=\"language-js\"><span class=\"keyword\">var</span> foo=<span class=\"string\">'bar'</span>;</code></pre>\n";
+      template = Handlebars.compile(codeExample);
+      template().should.equal(codeExampleExpected);
+      return done();
     });
   });
 

--- a/test/helpers/math_test.js
+++ b/test/helpers/math_test.js
@@ -15,7 +15,6 @@
     return describe('{{add value 5}}', function() {
       return it('should return the sum of two numbers.', function() {
         var source, template;
-
         source = '{{add value 5}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(10);
@@ -27,7 +26,6 @@
     return describe('{{subtract value 5}}', function() {
       return it('should return the difference of two numbers.', function() {
         var source, template;
-
         source = '{{subtract value 5}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(0);
@@ -39,7 +37,6 @@
     return describe('{{divide value 5}}', function() {
       return it('should return the division of two numbers.', function() {
         var source, template;
-
         source = '{{divide value 5}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(1);
@@ -51,7 +48,6 @@
     return describe('{{multiply value 5}}', function() {
       return it('should return the multiplication of two numbers.', function() {
         var source, template;
-
         source = '{{multiply value 5}}';
         template = Handlebars.compile(source);
         return template(context).should.equal(25);
@@ -63,7 +59,6 @@
     return describe('{{floor 5}}', function() {
       return it('should return the value rounded down to the nearest integer.', function() {
         var source, template;
-
         source = '{{floor value}}';
         template = Handlebars.compile(source);
         return template(context = {
@@ -77,7 +72,6 @@
     return describe('{{ceil 5}}', function() {
       return it('should return the value rounded up to the nearest integer.', function() {
         var source, template;
-
         source = '{{ceil value}}';
         template = Handlebars.compile(source);
         return template(context = {
@@ -91,7 +85,6 @@
     return describe('{{round 5}}', function() {
       return it('should return the value rounded to the nearest integer.', function() {
         var source, template;
-
         source = '{{round value}}';
         template = Handlebars.compile(source);
         return template(context = {
@@ -105,7 +98,6 @@
     return describe('{{sum value 67 80}}', function() {
       return it('should return the sum of multiple numbers.', function() {
         var source, template;
-
         source = '{{sum value 67 80}}';
         template = Handlebars.compile(source);
         return template(context = {
@@ -119,7 +111,6 @@
     return describe('{{sum 1 2 3}}', function() {
       return it('should return the sum of multiple numbers.', function() {
         var source, template;
-
         source = '{{sum 1 2 3}}';
         template = Handlebars.compile(source);
         return template().should.equal(6);
@@ -131,7 +122,6 @@
     return describe('{{sum value}}', function() {
       return it('should return the total sum of array.', function() {
         var source, template;
-
         source = '{{sum value}}';
         template = Handlebars.compile(source);
         return template(context = {
@@ -145,7 +135,6 @@
     return describe('{{sum value 5}}', function() {
       return it('should return the total sum of array and numbers.', function() {
         var source, template;
-
         source = '{{sum value 5}}';
         template = Handlebars.compile(source);
         return template(context = {

--- a/test/helpers/miscellaneous_test.js
+++ b/test/helpers/miscellaneous_test.js
@@ -11,7 +11,6 @@
     return describe('{{default title "Not title available."}}', function() {
       return it('should provide a default or fallback value if a value doesn\'t exist.', function() {
         var context, source, template;
-
         source = '{{default title "No title available."}}';
         template = Handlebars.compile(source);
         context = {

--- a/test/helpers/numbers_test.js
+++ b/test/helpers/numbers_test.js
@@ -11,7 +11,6 @@
     describe('{{toFixed value}}', function() {
       return it('should return the value rounded to the nearest integer.', function() {
         var context, source, template;
-
         source = '{{toFixed value}}';
         template = Handlebars.compile(source);
         context = {
@@ -23,7 +22,6 @@
     return describe('{{toFixed value 3}}', function() {
       return it('should return the value rounded exactly n digits after the decimal place.', function() {
         var context, source, template;
-
         source = '{{toFixed value 3}}';
         template = Handlebars.compile(source);
         context = {
@@ -38,7 +36,6 @@
     describe('{{toPrecision value}}', function() {
       return it('Returns the number in fixed-point or exponential notation rounded to n significant digits.', function() {
         var context, source, template;
-
         source = '{{toPrecision value}}';
         template = Handlebars.compile(source);
         context = {
@@ -50,7 +47,6 @@
     return describe('{{toPrecision value 4}}', function() {
       return it('should return the value rounded exactly n digits after the decimal place.', function() {
         var context, source, template;
-
         source = '{{toPrecision value 4}}';
         template = Handlebars.compile(source);
         context = {
@@ -65,7 +61,6 @@
     describe('{{toExponential value}}', function() {
       return it('should return the number in fixed-point or exponential notation rounded to n significant digits.', function() {
         var context, source, template;
-
         source = '{{toExponential value}}';
         template = Handlebars.compile(source);
         context = {
@@ -77,7 +72,6 @@
     return describe('{{toExponential value 5}}', function() {
       return it('should return the number in fixed-point or exponential notation rounded to exactly n significant digits.', function() {
         var context, source, template;
-
         source = '{{toExponential value 5}}';
         template = Handlebars.compile(source);
         context = {
@@ -92,7 +86,6 @@
     return describe('{{toInt value}}', function() {
       return it('should return an integer.', function() {
         var context, source, template;
-
         source = '{{toInt value}}';
         template = Handlebars.compile(source);
         context = {
@@ -107,7 +100,6 @@
     return describe('{{toFloat value}}', function() {
       return it('should return a floating point number.', function() {
         var context, source, template;
-
         source = '{{toFloat value}}';
         template = Handlebars.compile(source);
         context = {
@@ -122,7 +114,6 @@
     return describe('{{addCommas value}}', function() {
       return it('should add commas to a number.', function() {
         var context, source, template;
-
         source = '{{addCommas value}}';
         template = Handlebars.compile(source);
         context = {
@@ -137,7 +128,6 @@
     describe('{{toAbbr value}}', function() {
       return it('should formats (and approximates) a number into abbreviation based on a value.', function() {
         var context, source, template;
-
         source = '{{toAbbr value}}';
         template = Handlebars.compile(source);
         context = {
@@ -149,7 +139,6 @@
     return describe('{{toAbbr value 3}}', function() {
       return it('should formats (and approximates) a number into abbreviation based on a value and include decimal.', function() {
         var context, source, template;
-
         source = '{{toAbbr value 3}}';
         template = Handlebars.compile(source);
         context = {

--- a/test/helpers/path_test.js
+++ b/test/helpers/path_test.js
@@ -11,21 +11,18 @@
     return describe('{{extname src}}', function() {
       it('should return the extname of a given file path', function() {
         var source, template;
-
         source = '{{extname "package.json"}}';
         template = Handlebars.compile(source);
         return template().should.equal('json');
       });
       it('should return the extname of a given file path', function() {
         var source, template;
-
         source = '{{extname "docs/toc.md"}}';
         template = Handlebars.compile(source);
         return template().should.equal('md');
       });
       return it('should return the extname of a given file path', function() {
         var source, template;
-
         source = '{{extname "AUTHORS"}}';
         template = Handlebars.compile(source);
         return template().should.equal('AUTHORS');
@@ -37,21 +34,18 @@
     return describe('{{basename src}}', function() {
       it('should return the basename of a given file path', function() {
         var source, template;
-
         source = '{{basename "docs/toc.md"}}';
         template = Handlebars.compile(source);
         return template().should.equal('toc');
       });
       it('should return the basename of a given file path', function() {
         var source, template;
-
         source = '{{basename "docs/toc"}}';
         template = Handlebars.compile(source);
         return template().should.equal('toc');
       });
       return it('should return the basename of a given file path', function() {
         var source, template;
-
         source = '{{basename "package.json"}}';
         template = Handlebars.compile(source);
         return template().should.equal('package');
@@ -63,7 +57,6 @@
     return describe('{{filename src}}', function() {
       return it('should return the filename of a given file path', function() {
         var source, template;
-
         source = '{{filename "docs/toc.md"}}';
         template = Handlebars.compile(source);
         return template().should.equal('toc.md');
@@ -75,14 +68,12 @@
     return describe('{{dirname src}}', function() {
       it('should return the directory name of the given file path', function() {
         var source, template;
-
         source = '{{dirname "docs/toc.md"}}';
         template = Handlebars.compile(source);
         return template().should.equal('docs');
       });
       return it('should return the directory name of the given file path', function() {
         var source, template;
-
         source = '{{dirname "examples/result/md/path.md"}}';
         template = Handlebars.compile(source);
         return template().should.equal('examples/result/md');
@@ -94,14 +85,12 @@
     return describe('{{relative a b}}', function() {
       it('should return the relative path from file A to file B', function() {
         var source, template;
-
         source = '{{relative "dist/docs.html" "index.html"}}';
         template = Handlebars.compile(source);
         return template().should.equal('../index.html');
       });
       return it('should return the relative path from file A to file B', function() {
         var source, template;
-
         source = '{{relative "examples/result/md/path.md" "examples/assets"}}';
         template = Handlebars.compile(source);
         return template().should.equal('../../assets');

--- a/test/helpers/strings_test.js
+++ b/test/helpers/strings_test.js
@@ -11,7 +11,6 @@
     return describe('{{lowercase string}}', function() {
       return it('should return the string in lowercase', function() {
         var source, template;
-
         source = '{{lowercase "BENDER SHOULD NOT BE ALLOWED ON TV"}}';
         template = Handlebars.compile(source);
         return template().should.equal('bender should not be allowed on tv');
@@ -23,7 +22,6 @@
     return describe('{{uppercase string}}', function() {
       return it('should return the string in uppercase', function() {
         var source, template;
-
         source = '{{uppercase "bender should not be allowed on tv"}}';
         template = Handlebars.compile(source);
         return template().should.equal('BENDER SHOULD NOT BE ALLOWED ON TV');
@@ -35,7 +33,6 @@
     return describe('{{capitalizeFirst string}}', function() {
       return it('should return the string with the first word capitalized.', function() {
         var source, template;
-
         source = '{{capitalizeFirst "bender should not be allowed on tv"}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender should not be allowed on tv');
@@ -47,7 +44,6 @@
     return describe('{{capitalizeEach string}}', function() {
       return it('should return the string with the every word capitalized.', function() {
         var source, template;
-
         source = '{{capitalizeEach "bender should not bE allowed on tV"}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender Should Not BE Allowed On TV');
@@ -59,7 +55,6 @@
     return describe('{{titleize string}}', function() {
       return it('should return the string in title case.', function() {
         var source, template;
-
         source = '{{titleize "Bender-should-Not-be-allowed_on_Tv"}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender Should Not Be Allowed On Tv');
@@ -71,7 +66,6 @@
     return describe('{{sentence string}}', function() {
       return it('should capitalize the first word of each sentence in a string and convert the rest of the sentence to lowercase.', function() {
         var source, template;
-
         source = '{{sentence "bender should NOT be allowed on TV. fry SHOULD be allowed on TV."}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender should not be allowed on tv. Fry should be allowed on tv.');
@@ -83,7 +77,6 @@
     return describe('{{reverse string}}', function() {
       return it('should return the string in reverse.', function() {
         var source, template;
-
         source = '{{reverse "bender should NOT be allowed on TV."}}';
         template = Handlebars.compile(source);
         return template().should.equal('.VT no dewolla eb TON dluohs redneb');
@@ -95,7 +88,6 @@
     describe('{{truncate string 31}}', function() {
       return it('should return then string truncated by a specified length.', function() {
         var source, template;
-
         source = '{{truncate "Bender should not be allowed on tv." 31}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender should not be allowed on');
@@ -104,7 +96,6 @@
     return describe('{{truncate string 31 "..."}}', function() {
       return it('should return then string truncated by a specified length, providing a custom string to denote an omission.', function() {
         var source, template;
-
         source = '{{truncate "Bender should not be allowed on tv." 31 "..."}}';
         template = Handlebars.compile(source);
         return template().should.equal('Bender should not be allowed...');
@@ -116,7 +107,6 @@
     return describe('{{center string}}', function() {
       return it('should return the string centered by using non-breaking spaces.', function() {
         var source, template;
-
         source = '{{center "Bender should not be allowed on tv." 2}}';
         template = Handlebars.compile(source);
         return template().should.equal('&amp;nbsp;&amp;nbsp;Bender should not be allowed on tv.&amp;nbsp;&amp;nbsp;');
@@ -128,7 +118,6 @@
     return describe("{{hyphenate string}}", function() {
       return it("should return the string with spaces replaced with hyphens.", function() {
         var source, template;
-
         source = '{{hyphenate "Bender should not be allowed on tv."}}';
         template = Handlebars.compile(source);
         return template().should.equal("Bender-should-not-be-allowed-on-tv.");
@@ -140,7 +129,6 @@
     return describe("{{hyphenate string}}", function() {
       return it("should return the string with periods replaced with hyphens.", function() {
         var source, template;
-
         source = '{{dashify "Bender.should.not.be.allowed.on.tv."}}';
         template = Handlebars.compile(source);
         return template().should.equal("Bender-should-not-be-allowed-on-tv-");

--- a/test/helpers/url_test.js
+++ b/test/helpers/url_test.js
@@ -11,21 +11,18 @@
     return describe('{{url_resolve base href}}', function() {
       it('should take a base URL, and a href URL,' + 'and resolve them as a browser would for an anchor tag', function() {
         var source, template;
-
         source = '{{url_resolve "/one/two/three" "four"}}';
         template = Handlebars.compile(source);
         return template().should.equal("/one/two/four");
       });
       it('should take a base URL, and a href URL, and resolve them as a browser would for an anchor tag', function() {
         var source, template;
-
         source = '{{url_resolve "http://example.com/" "/one"}}';
         template = Handlebars.compile(source);
         return template().should.equal("http://example.com/one");
       });
       return it('should take a base URL, and a href URL, and resolve them as a browser would for an anchor tag', function() {
         var source, template;
-
         source = '{{url_resolve "http://example.com/one" "/two"}}';
         template = Handlebars.compile(source);
         return template().should.equal("http://example.com/two");

--- a/test/utils/dates_test.js
+++ b/test/utils/dates_test.js
@@ -9,7 +9,6 @@
     return describe('default padCharacter', function() {
       return it('should return a number with 0s', function() {
         var actual, expected, num;
-
         num = 123;
         expected = '000123';
         actual = Dates.padNumber(num, 6);

--- a/test/utils/markdown_test.js
+++ b/test/utils/markdown_test.js
@@ -14,18 +14,15 @@
 
   describe("Converting Markdown Files", function() {
     var simple, simpleExpected;
-
     simple = "## Some Markdown\n\n - one\n - two\n - three\n\n[Click here](http://github.com)";
     simpleExpected = "<h2>Some Markdown</h2>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n<p><a href=\"http://github.com\">Click here</a></p>\n";
     it("should convert a markdown string", function(done) {
       var data;
-
       data = markdown.convert(simple);
       return done();
     });
     it("should read a markdown file", function(done) {
       var data, filename;
-
       filename = path.join(__dirname, '../files/simple1.md');
       data = markdown.read(filename);
       expect(data).to.equal(simpleExpected);
@@ -33,7 +30,6 @@
     });
     return it("should convert a markdown file with code highlighting", function(done) {
       var data, filename;
-
       filename = path.join(__dirname, '../files/complex1.md');
       data = markdown.read(filename);
       return done();

--- a/test/utils/utils_test.js
+++ b/test/utils/utils_test.js
@@ -8,7 +8,6 @@
   describe('trim', function() {
     return it('should trim off white space', function() {
       var actual, before, expected;
-
       before = "  test  ";
       expected = "test";
       actual = Utils.trim(before);
@@ -19,7 +18,6 @@
   describe('lowercase', function() {
     return it('should convert a string to lowercase', function() {
       var actual, before, expected;
-
       before = "This IS a TEST StRiNg";
       expected = "this is a test string";
       actual = Utils.lowerCase(before);
@@ -31,7 +29,6 @@
     describe('buildObjectPaths', function() {
       return it('should return an array of paths that look like file paths but with object keys', function() {
         var actual, expected, input;
-
         input = {
           foo: 'bar',
           baz: {
@@ -46,7 +43,6 @@
     return describe('globObject', function() {
       return it('should return a new object only containing keys that match the given pattern', function() {
         var actual, expected, input;
-
         input = {
           foo: 'bar',
           baz: {


### PR DESCRIPTION
This was just using the root level options. Updated to use `marked` per #37.

I added a test specifically for `langPrefix` to verify that it's working this time.

I also got the latest grunt-contrib-coffee so the compiled formatting is back to normal.
