### PR TITLE
deep clone array inside withSort helper, in case the origin data is affected

### DIFF
--- a/lib/helpers/helpers-collections.js
+++ b/lib/helpers/helpers-collections.js
@@ -6,7 +6,7 @@
 
 var Handlebars = require('../helpers/helpers').Handlebars;
 var Utils = require('../utils/utils');
-
+var _ = require('lodash');
 
 // The module to be exported
 var helpers = module.exports = {
@@ -220,6 +220,7 @@ var helpers = module.exports = {
 
   withSort: function (array, field, options) {
     var getDescendantProp, item, result, i, len;
+    array = _.cloneDeep(array);
     getDescendantProp = function (obj, desc) {
       var arr;
       arr = desc.split(".");

--- a/test/helpers/collections_test.js
+++ b/test/helpers/collections_test.js
@@ -203,6 +203,18 @@ describe('withSort', function() {
         ]
       };
       template(_context).should.equal('Fry: -12 <br>Bender: 239 <br>Leela: 8021 <br>');
+      _context.collection.should.eql([
+          {
+            name: 'Leela',
+            deliveries: 8021
+          }, {
+            name: 'Bender',
+            deliveries: 239
+          }, {
+            name: 'Fry',
+            deliveries: -12
+          }
+        ]);
     });
   });
 });


### PR DESCRIPTION
withSort should just sort data to be output, not the origin data.
For the case, I write 

``` html
<ul>
{{#withSort pages "data.index"}}
    <li class="item"><a href="{{pagename}}">{{titleize data.title}}</a></li>
{{/withSort}}
</ul>
```

with three page templates as below

``` html

---
title: Home
num: 0 

---
{{md 'README.md'}}
```

``` html

---
title: Layout
num: 1
files: ['content/layout/*.md']

---
<h1>{{title}}</h1>
{{#each files}}
  {{md this}}
{{/each}}
```

``` html

---
title: Components
index: 2
files: ['content/components/*.md']

---
<h1>{{title}}</h1>
{{#each files}}
  {{md this}}
{{/each}}
```

if the withSort directive sort the origin array, the grunt task will output

```
Assembling _site/components.html OK
Assembling _site/layout.html OK
Assembling _site/components.html OK
```
