### PR TITLE
Adding 'filter' helper for collections

### DIFF
--- a/lib/helpers/helpers-collections.js
+++ b/lib/helpers/helpers-collections.js
@@ -340,6 +340,42 @@ var helpers = {
     }
   },
 
+  filter: function(array, value, options) {
+
+    var data = void 0;
+    var content = '';
+    var results = [];
+
+    if(options.data) {
+      data = Handlebars.createFrame(options.data);
+    }
+
+    // filtering on a specific property
+    if(options.hash && options.hash.property) {
+
+      var search = {};
+      search[options.hash.property] = value;
+      results = _.filter(array, search);
+
+    } else {
+
+      // filtering on a string value
+      results = _.filter(array, function(v, k) {
+        return value === v;
+      });
+
+    }
+    
+    if(results && results.length > 0) {
+      for(var i=0; i < results.length; i++){
+        content += options.fn(results[i], {data: data});
+      }
+    } else {
+      content = options.inverse(this);
+    }
+    return content;
+  },
+
   /**
    * {{iterate}}
    *

--- a/test/helpers/collections_test.js
+++ b/test/helpers/collections_test.js
@@ -274,6 +274,36 @@ describe('inArray', function() {
   });
 });
 
+describe('filter', function() {
+  describe('{{#filter collection "Fry"}} \n I\'m walking on sunshine! \n {{else}} \n I\'m walking in darkness. \n {{/filter}}', function() {
+    it('should conditionally render a block if a specified value is in the collection.', function() {
+      source = '{{#filter collection "Fry"}}I\'m walking on sunshine!{{else}}I\'m walking in darkness.{{/filter}}';
+      template = Handlebars.compile(source);
+      template(context).should.equal('I\'m walking on sunshine!');
+    });
+  });
+
+  describe('{{#filter collection "Fry" property="first"}} \n {{this.first}} \n {{else}} \n Not found! \n {{/filter}}', function() {
+    var context = {
+      collection: [
+        { first: 'Amy', last: 'Wong'},
+        { first: 'Bender'},
+        { title: 'Dr.', last: 'Zoidberg'}, 
+        { first: 'Fry'}, 
+        { first: 'Hermes', last: 'Conrad'},
+        { first: 'Leela'},
+        { title: 'Professor', last: 'Farnsworth'},
+        { first: 'Scruffy'}
+      ]
+    };
+    it('should render a block for each object that has a "first" property with the value "Fry".', function() {
+      source = '{{#filter collection "Fry" property="first"}}{{this.first}}{{else}}Not found!{{/filter}}';
+      template = Handlebars.compile(source);
+      template(context).should.equal('Fry');
+    });
+  });
+});
+
 describe('eachIndex', function() {
   describe('{{#eachIndex collection}} \n {{item}} is {{index}} \n {{/eachIndex}}', function() {
     it('should render the block using the array and each item\'s index.', function() {


### PR DESCRIPTION
Adding a 'filter' helper for collections that can filter on
strings or object property/value:

``` handlebars
{{#filter collection "SearchValue"}}
  <!-- render something for each value that comes back -->
  {{this}}
{{else}}
  Nothing returned
{{/filter}}
```

``` handlebars
{{#filter collection "SearchValue" property="SearchProperty"}}
  <!-- render something for each value that comes back -->
  {{this.SearchProperty}}
{{else}}
  Nothing returned
{{/filter}}
```
