### PR TITLE
Unicode characters support in titleize helper

### DIFF
--- a/lib/helpers/helpers-strings.js
+++ b/lib/helpers/helpers-strings.js
@@ -129,7 +129,7 @@ var helpers = {
   titleize: function (str) {
     if(str && typeof str === "string") {
       var title = str.replace(/[ \-_]+/g, ' ');
-      var words = title.match(/\w+/g);
+      var words = title.split(' ');
       var capitalize = function (word) {
         return word.charAt(0).toUpperCase() + word.slice(1);
       };


### PR DESCRIPTION
Strings in JavaScript are 16 bit, so strings and RegExp objects can contain unicode characters, but most of the special characters like '\b', '\d', '\w' only support ascii.
