### PR TITLE
fix(package.json): ‘js-prettify’ dep missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-mocha-test": "~0.2.0",
     "grunt-readme": "~0.1.5",
-    "should": "~1.2.2"
+    "should": "~1.2.2",
+    "js-prettify": "~1.4.0"
   },
   "keywords": [
     "assemble helpers",


### PR DESCRIPTION
- ./lib/utils/html.js references `require(‘js-prettify’)` but it wasn’t in package.json
