### PR TITLE
Fix nap test

### DIFF
--- a/test/helpers/html_test.js
+++ b/test/helpers/html_test.js
@@ -22,7 +22,7 @@ describe('html', function() {
 
     before(function() {
       nap({
-        publicDir: './test/actual/',
+        publicDir: path.resolve(__dirname, '../actual/'),
         mode: 'production',
         assets: {
           js: {


### PR DESCRIPTION
Upon cloning the repo this morning I discovered that one of the tests was failing. It appears to be because an absolute path was provided to nap for publicDir that pointed at the root filesystem.

This PR updates that to correctly locate where the /test/actual folder is at.
