### PR TITLE
helpers: comparison: add `ifNth` helper

### DIFF
--- a/lib/helpers/helpers-comparisons.js
+++ b/lib/helpers/helpers-comparisons.js
@@ -89,6 +89,20 @@ var helpers = {
   },
 
   /**
+   * ifNth
+   * Conditionally render a block if mod(nr, v) is 0
+   */
+  ifNth: function (nr, v, options) {
+    v = v+1;
+    console.log(nr, v, v % nr)
+    if (v % nr === 0) {
+      return options.fn(this);
+    } else {
+      return options.inverse(this);
+    }
+  },
+
+  /**
    * {{#compare}}...{{/compare}}
    *
    * @credit: OOCSS


### PR DESCRIPTION
Basically a modulo, useful inside `#each` with `@index`.

Example usage: handling clearfixes in responsive bootstrap grids

``` html
<div id="results" class="row">
  {{#each results}}

  <!-- 2 per row; 3 on small; 4 on medium and larger -->
  <div class="col-xs-6 col-sm-4 col-md-3">
    {{foo}}
  </div>

  <!-- make clearfixes for 3 kinds of grids -->
  {{#ifNth "2" @index}}
   <div class="clearfix visible-xs"></div>
  {{/ifNth}}

  {{#ifNth "3" @index}}
   <div class="clearfix visible-sm"></div>
  {{/ifNth}}

  {{#ifNth "4" @index}}
   <div class="clearfix visible-md visible-lg"></div>
  {{/ifNth}}

  {{/each}}
</div> <!-- end row  -->
```
