### PR TITLE
Number Object comparison fix

### DIFF
--- a/lib/helpers/helpers-comparisons.js
+++ b/lib/helpers/helpers-comparisons.js
@@ -45,6 +45,10 @@ var helpers = {
   },
 
   is: function (value, test, options) {
+    // This converts Number Objects to numbers
+    // so they are comparable
+    value = +value ? +value : value;
+    test = +test ? +test : test;
     if (value === test) {
       return options.fn(this);
     } else {
@@ -53,6 +57,8 @@ var helpers = {
   },
 
   isnt: function (value, test, options) {
+    value = +value ? +value : value;
+    test = +test ? +test : test;
     if (value !== test) {
       return options.fn(this);
     } else {


### PR DESCRIPTION
In some situations like iterating over objects with numeral values, `this` becomes a Number Object and not actually a number, in those situations, comparing with other numbers is impossible:

```
  var x = new Number(2);
  var y = 2;
  x == y // true
  x !== y // true
```

A template like this wouldn't work properly ( it will output 'Blablabla' everytime because both 2 !== 2 and 1 !== 2 result in true ):

```
 object = {
    x: 2,
    y: 1
 }
 {{#each object}}
    {{#isnt this 2}}
      Blablabla
    {{/is}}
  {{/each}}
```

I haven't really digged into this library, so I don't know if this problem persists anywhere else, I hope it doesn't.
