### PR TITLE
Updated comparison helpers so that they can be used in subexpressions

### DIFF
--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -8,7 +8,7 @@ var utils = require('./utils');
  * Expose `helpers`
  */
 
-var helpers = module.exports;
+var helpers = {};
 
 /**
  * Block helper that renders the block if **both** of the given values
@@ -24,15 +24,7 @@ var helpers = module.exports;
  */
 
 helpers.and = function(a, b, options) {
-  // if block helper
-  if( options.fn ) {
-    if (a && b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { //if non block helper
-    return a && b;
-  }
+  return a && b;
 };
 
 /**
@@ -90,15 +82,8 @@ helpers.compare = function(a, operator, b, options) {
       throw new Error('helper {{compare}}: invalid operator: `' + operator + '`');
     }
   }
-  // if block helper
-  if( options.fn ) {
-    if (result === false) {
-      return options.inverse(this);
-    }
-    return options.fn(this);
-  } else { // if non-block helper
-    return result;
-  }
+  
+  return result;
 };
 
 /**
@@ -130,17 +115,8 @@ helpers.contains = function(collection, value, startIndex, options) {
     options = startIndex;
     startIndex = undefined;
   }
-  var result = utils.contains(collection, value, startIndex);
   
-  // if block helper
-  if( options.fn ) {
-    if (result) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return result;
-  }
+  return utils.contains(collection, value, startIndex);
 };
 
 /**
@@ -164,15 +140,8 @@ helpers.gt = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  // if block helper
-  if( options.fn ) {
-    if (a > b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a > b;
-  }
+  
+  return a > b;
 };
 
 /**
@@ -197,15 +166,8 @@ helpers.gte = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  // if block helper
-  if( options.fn ) {
-    if (a >= b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a >= b;
-  }
+  
+  return a >= b;
 };
 
 /**
@@ -222,7 +184,7 @@ helpers.gte = function(a, b, options) {
 
 helpers.has = function(/*value, pattern, options*/) {
   var value, pattern, options;
-  //TODO add discussion about this in pull request
+  
   if( arguments.length === 2 ) {
     options = arguments[1];
   } else if ( arguments.length === 1 ) {
@@ -233,29 +195,23 @@ helpers.has = function(/*value, pattern, options*/) {
     options = arguments[2];
   }
   
-  var result;
 
   if( value === undefined || pattern === undefined) {
-    result = false;
-  } else if ( ( (Array.isArray(value) || isString(value)) && isString(pattern) )
-           && (value.indexOf(pattern) > -1) ) {
-    result = true;
-  } else if (isObject(value) && isString(pattern) && pattern in value) {
-    result = true;
-  } else {
-    result = false;
+    return false;
+  } 
+  
+  if ((Array.isArray(value) || isString(value)) && isString(pattern) ) {
+    if (value.indexOf(pattern) > -1) { 
+      return true;
+    }
   }
   
-  // if block helper
-  if( options.fn ) {
-    if( result ) {
-      return options.fn(this);
-    } else {
-      return options.inverse(this);
-    }
-  } else { // if non-block helper
-    return result;
+  if (isObject(value) && isString(pattern) && pattern in value) {
+    return true;
   }
+  
+  return false;
+  
 };
 
 /**
@@ -278,15 +234,8 @@ helpers.eq = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  // if block helper
-  if( options.fn ) {
-    if (a === b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a === b;
-  }
+  
+  return a === b;
 };
 
 /**
@@ -307,17 +256,7 @@ helpers.eq = function(a, b, options) {
  */
 
 helpers.ifEven = function(num, options) {
-  var result = utils.isEven(num);
-  
-  // if block helper
-  if( options.fn ) {
-    if (result) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return result;
-  }
+  return utils.isEven(num);
 };
 
 /**
@@ -334,17 +273,7 @@ helpers.ifEven = function(num, options) {
  */
 
 helpers.ifNth = function(a, b, options) {
-  var result = (++b % a === 0);
-  
-  // if block helper
-  if( options.fn ) {
-    if (result) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return result;
-  }
+  return (++b % a === 0);
 };
 
 /**
@@ -366,17 +295,7 @@ helpers.ifNth = function(a, b, options) {
  */
 
 helpers.ifOdd = function(val, options) {
-  var result = utils.isOdd(val);
-  
-  // if block helper
-  if( options.fn ) {
-    if (result) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return result;
-  }
+  return utils.isOdd(val);
 };
 
 /**
@@ -398,15 +317,7 @@ helpers.is = function(a, b, options) {
     b = options.hash.compare;
   }
   
-  // if block helper
-  if( options.fn ) {
-    if (a === b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a === b;
-  }
+  return a === b;
 };
 
 /**
@@ -428,15 +339,7 @@ helpers.isnt = function(a, b, options) {
     b = options.hash.compare;
   }
   
-  // if block helper
-  if( options.fn ) {
-    if (a !== b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a !== b;
-  }
+  return a !== b;
 };
 
 /**
@@ -460,15 +363,7 @@ helpers.lt = function(a, b, options) {
     b = options.hash.compare;
   }
   
-  // if block helper
-  if( options.fn ) {
-    if (a < b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a < b;
-  }
+  return a < b;
 };
 
 /**
@@ -494,15 +389,7 @@ helpers.lte = function(a, b, options) {
     b = options.hash.compare;
   }
   
-  // if block helper
-  if( options.fn ) {
-    if (a <= b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return a <= b;
-  }
+  return a <= b;
 };
 
 /**
@@ -520,15 +407,7 @@ helpers.lte = function(a, b, options) {
  */
 
 helpers.neither = function(a, b, options) {
-  // if block helper
-  if( options.fn ) {
-    if (!a && !b) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !a && !b;
-  }
+  return !a && !b;
 };
 
 /**
@@ -563,15 +442,7 @@ helpers.or = function(/* any, any, ..., options */) {
     i++;
   }
   
-  // if block helper
-  if( options.fn ) {
-    if (success) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return success;
-  }
+  return success;
 };
 
 /**
@@ -588,15 +459,7 @@ helpers.or = function(/* any, any, ..., options */) {
  */
 
 helpers.unlessEq = function(context, options) {
-  // if block helper
-  if( options.fn ) {
-    if ( !(context == options.hash.compare) ) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !(context === options.hash.compare);
-  }
+  return !(context === options.hash.compare);
 };
 
 /**
@@ -612,15 +475,7 @@ helpers.unlessEq = function(context, options) {
  */
 
 helpers.unlessGt = function(context, options) {
-  // if block helper
-  if( options.fn ) {
-    if ( !(context > options.hash.compare) ) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !(context > options.hash.compare);
-  }
+  return !(context > options.hash.compare);
 };
 
 /**
@@ -636,15 +491,7 @@ helpers.unlessGt = function(context, options) {
  */
 
 helpers.unlessLt = function(context, options) {
-  // if block helper
-  if( options.fn ) {
-    if ( !(context < options.hash.compare) ) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !(context < options.hash.compare);
-  }
+  return !(context < options.hash.compare);
 };
 
 /**
@@ -659,16 +506,8 @@ helpers.unlessLt = function(context, options) {
  * @api public
  */
 
-helpers.unlessGteq = function(context, options) { 
-  // if block helper
-  if( options.fn ) {
-    if ( !(context >= options.hash.compare) ) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !(context >= options.hash.compare);
-  }
+helpers.unlessGteq = function(context, options) {
+  return !(context >= options.hash.compare);
 };
 
 /**
@@ -684,13 +523,27 @@ helpers.unlessGteq = function(context, options) {
  */
 
 helpers.unlessLteq = function(context, options) {
-  // if block helper
-  if( options.fn ) {
-    if ( !(context <= options.hash.compare) ) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  } else { // if non-block helper
-    return !(context <= options.hash.compare);
-  }
+  return !(context <= options.hash.compare);
 };
+
+module.exports = {};
+
+Object.keys(helpers).map(function(key) {
+  var helper = helpers[key];
+  module.exports[key] = function() {
+    var options = arguments[arguments.length - 1];
+    var result = helper.apply(this, arguments);
+    // used as block helper
+    if( typeof result !== 'boolean') {
+      throw new Error('helper has to return a boolean');
+    } else if ( options.fn) {
+      if (result) {
+        return options.fn(this);
+      } else {
+        return options.inverse(this);
+      }
+    } else { // used as non-block helper
+      return result;
+    }
+  };
+});

--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -24,10 +24,15 @@ var helpers = module.exports;
  */
 
 helpers.and = function(a, b, options) {
-  if (a && b) {
-    return options.fn(this);
+  // if block helper
+  if( options.fn ) {
+    if (a && b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { //if non block helper
+    return a && b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -85,11 +90,15 @@ helpers.compare = function(a, operator, b, options) {
       throw new Error('helper {{compare}}: invalid operator: `' + operator + '`');
     }
   }
-
-  if (result === false) {
-    return options.inverse(this);
+  // if block helper
+  if( options.fn ) {
+    if (result === false) {
+      return options.inverse(this);
+    }
+    return options.fn(this);
+  } else { // if non-block helper
+    return result;
   }
-  return options.fn(this);
 };
 
 /**
@@ -121,10 +130,17 @@ helpers.contains = function(collection, value, startIndex, options) {
     options = startIndex;
     startIndex = undefined;
   }
-  if (utils.contains(collection, value, startIndex)) {
-    return options.fn(this);
+  var result = utils.contains(collection, value, startIndex);
+  
+  // if block helper
+  if( options.fn ) {
+    if (result) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return result;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -148,10 +164,15 @@ helpers.gt = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a > b) {
-    return options.fn(this);
+  // if block helper
+  if( options.fn ) {
+    if (a > b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a > b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -176,10 +197,15 @@ helpers.gte = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a >= b) {
-    return options.fn(this);
+  // if block helper
+  if( options.fn ) {
+    if (a >= b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a >= b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -194,24 +220,42 @@ helpers.gte = function(a, b, options) {
  * @api public
  */
 
-helpers.has = function(value, pattern, options) {
-  if (arguments.length === 2) {
-    return pattern.inverse(this);
+helpers.has = function(/*value, pattern, options*/) {
+  var value, pattern, options;
+  //TODO add discussion about this in pull request
+  if( arguments.length === 2 ) {
+    options = arguments[1];
+  } else if ( arguments.length === 1 ) {
+    options = arguments[0];
+  } else {
+    value   = arguments[0];
+    pattern = arguments[1];
+    options = arguments[2];
   }
+  
+  var result;
 
-  if (arguments.length === 1) {
-    return value.inverse(this);
+  if( value === undefined || pattern === undefined) {
+    result = false;
+  } else if ( ( (Array.isArray(value) || isString(value)) && isString(pattern) )
+           && (value.indexOf(pattern) > -1) ) {
+    result = true;
+  } else if (isObject(value) && isString(pattern) && pattern in value) {
+    result = true;
+  } else {
+    result = false;
   }
-
-  if ((Array.isArray(value) || isString(value)) && isString(pattern)) {
-    if (value.indexOf(pattern) > -1) {
+  
+  // if block helper
+  if( options.fn ) {
+    if( result ) {
       return options.fn(this);
+    } else {
+      return options.inverse(this);
     }
+  } else { // if non-block helper
+    return result;
   }
-  if (isObject(value) && isString(pattern) && pattern in value) {
-    return options.fn(this);
-  }
-  return options.inverse(this);
 };
 
 /**
@@ -234,10 +278,15 @@ helpers.eq = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a === b) {
-    return options.fn(this);
+  // if block helper
+  if( options.fn ) {
+    if (a === b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a === b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -258,9 +307,17 @@ helpers.eq = function(a, b, options) {
  */
 
 helpers.ifEven = function(num, options) {
-  return utils.isEven(num)
-    ? options.fn(this)
-    : options.inverse(this);
+  var result = utils.isEven(num);
+  
+  // if block helper
+  if( options.fn ) {
+    if (result) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return result;
+  }
 };
 
 /**
@@ -277,10 +334,17 @@ helpers.ifEven = function(num, options) {
  */
 
 helpers.ifNth = function(a, b, options) {
-  if (++b % a === 0) {
-    return options.fn(this);
+  var result = (++b % a === 0);
+  
+  // if block helper
+  if( options.fn ) {
+    if (result) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return result;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -302,9 +366,17 @@ helpers.ifNth = function(a, b, options) {
  */
 
 helpers.ifOdd = function(val, options) {
-  return utils.isOdd(val)
-    ? options.fn(this)
-    : options.inverse(this);
+  var result = utils.isOdd(val);
+  
+  // if block helper
+  if( options.fn ) {
+    if (result) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return result;
+  }
 };
 
 /**
@@ -325,10 +397,16 @@ helpers.is = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a === b) {
-    return options.fn(this);
+  
+  // if block helper
+  if( options.fn ) {
+    if (a === b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a === b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -349,10 +427,16 @@ helpers.isnt = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a !== b) {
-    return options.fn(this);
+  
+  // if block helper
+  if( options.fn ) {
+    if (a !== b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a !== b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -375,10 +459,16 @@ helpers.lt = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a < b) {
-    return options.fn(this);
+  
+  // if block helper
+  if( options.fn ) {
+    if (a < b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a < b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -403,10 +493,16 @@ helpers.lte = function(a, b, options) {
     options = b;
     b = options.hash.compare;
   }
-  if (a <= b) {
-    return options.fn(this);
+  
+  // if block helper
+  if( options.fn ) {
+    if (a <= b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return a <= b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -424,10 +520,15 @@ helpers.lte = function(a, b, options) {
  */
 
 helpers.neither = function(a, b, options) {
-  if (!a && !b) {
-    return options.fn(this);
+  // if block helper
+  if( options.fn ) {
+    if (!a && !b) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  } else { // if non-block helper
+    return !a && !b;
   }
-  return options.inverse(this);
 };
 
 /**
@@ -461,10 +562,15 @@ helpers.or = function(/* any, any, ..., options */) {
     }
     i++;
   }
-  if (success) {
-    return options.fn(this);
-  } else {
+  
+  // if block helper
+  if( options.fn ) {
+    if (success) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return success;
   }
 };
 
@@ -482,10 +588,15 @@ helpers.or = function(/* any, any, ..., options */) {
  */
 
 helpers.unlessEq = function(context, options) {
-  if (context === options.hash.compare) {
+  // if block helper
+  if( options.fn ) {
+    if ( !(context == options.hash.compare) ) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return !(context === options.hash.compare);
   }
-  return options.fn(this);
 };
 
 /**
@@ -501,10 +612,15 @@ helpers.unlessEq = function(context, options) {
  */
 
 helpers.unlessGt = function(context, options) {
-  if (context > options.hash.compare) {
+  // if block helper
+  if( options.fn ) {
+    if ( !(context > options.hash.compare) ) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return !(context > options.hash.compare);
   }
-  return options.fn(this);
 };
 
 /**
@@ -520,10 +636,15 @@ helpers.unlessGt = function(context, options) {
  */
 
 helpers.unlessLt = function(context, options) {
-  if (context < options.hash.compare) {
+  // if block helper
+  if( options.fn ) {
+    if ( !(context < options.hash.compare) ) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return !(context < options.hash.compare);
   }
-  return options.fn(this);
 };
 
 /**
@@ -538,11 +659,16 @@ helpers.unlessLt = function(context, options) {
  * @api public
  */
 
-helpers.unlessGteq = function(context, options) {
-  if (context >= options.hash.compare) {
+helpers.unlessGteq = function(context, options) { 
+  // if block helper
+  if( options.fn ) {
+    if ( !(context >= options.hash.compare) ) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return !(context >= options.hash.compare);
   }
-  return options.fn(this);
 };
 
 /**
@@ -558,8 +684,13 @@ helpers.unlessGteq = function(context, options) {
  */
 
 helpers.unlessLteq = function(context, options) {
-  if (context <= options.hash.compare) {
+  // if block helper
+  if( options.fn ) {
+    if ( !(context <= options.hash.compare) ) {
+      return options.fn(this);
+    }
     return options.inverse(this);
+  } else { // if non-block helper
+    return !(context <= options.hash.compare);
   }
-  return options.fn(this);
 };

--- a/test/comparison.js
+++ b/test/comparison.js
@@ -17,6 +17,18 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#and great magnificent}}A{{else}}B{{/and}}');
       assert.equal(fn({great: true, magnificent: false}), 'B');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if both values are truthy.', function() {
+        var fn = hbs.compile('{{and great magnificent}}');
+        assert.equal(fn({great: true, magnificent: true}), 'true');
+      });
+      
+      it('should return false if both values are not truthy.', function() {
+        var fn = hbs.compile('{{and great magnificent}}');
+        assert.equal(fn({great: true, magnificent: false}), 'false');
+      });
+    });
   });
 
   describe('compare', function() {
@@ -143,6 +155,111 @@ describe('comparison', function() {
         });
       });
     });
+    
+    describe('operators - non block helper', function() {
+      describe('==', function() {
+        var fn = hbs.compile('{{compare a "==" b}}');
+
+        it('should return true  if `a` equals `b`', function() {
+          assert(fn({a: '0', b: 0}), 'true');
+        });
+        it('should return false block if false', function() {
+          assert(fn({a: 'foo', b: 0}), 'false');
+        });
+      });
+
+      describe('===', function() {
+        var fn = hbs.compile('{{compare a "===" b}}');
+
+        it('should return true if `a` strictly equals `b`', function() {
+          assert(fn({a: '1', b: '1'}), 'true');
+        });
+        it('should return false if false', function() {
+          assert(fn({a: '1', b: 1}), 'false');
+        });
+      });
+
+      describe('!=', function() {
+        var fn = hbs.compile('{{compare a "!=" b}}');
+
+        it('should return true if `a` does not equal `b`', function() {
+          assert(fn({a: 10, b: '11'}), 'true');
+        });
+        it('should return false if false', function() {
+          assert(fn({a: 10, b: '10'}), 'false');
+        });
+      });
+
+      describe('!==', function() {
+        var fn = hbs.compile('{{compare a "!==" b}}');
+
+        it('should return true if `a` does not strictly equal `b`', function() {
+          assert(fn({a: 10, b: 11}), 'true');
+        });
+        it('should return false if false', function() {
+          assert(fn({a: 10, b: 10}), 'false');
+        });
+      });
+
+      describe('>', function() {
+        var fn = hbs.compile('{{compare a ">" b}}');
+
+        it('should return true if true.', function() {
+          assert(fn({a: 20, b: 15}), 'true');
+        });
+
+        it('should return false if false.', function() {
+          assert(fn({a: 14, b: 15}), 'false');
+        });
+      });
+
+      describe('<', function() {
+        var fn = hbs.compile('{{compare unicorns "<" ponies}}');
+
+        it('should return true if true.', function() {
+          assert(fn({unicorns: 5, ponies: 6}), 'true');
+        });
+
+        it('should return false if false.', function() {
+          assert(fn({unicorns: 7, ponies: 6}), 'false');
+        });
+      });
+
+      describe('>=', function() {
+        var fn = hbs.compile('{{compare a ">=" b}}');
+
+        it('should return true if true.', function() {
+          assert(fn({a: 20, b: 15}), 'true');
+        });
+
+        it('should return true if equal.', function() {
+          assert(fn({a: 15, b: 15}), 'true');
+        });
+
+        it('should return false if false.', function() {
+          assert(fn({a: 14, b: 15}), 'false');
+        });
+      });
+
+      describe('<=', function() {
+        var fn = hbs.compile('{{compare a "<=" b}}');
+
+        it('should return true if true.', function() {
+          assert(fn({a: 10, b: 15}), 'true');
+        });
+
+        it('should return false if false.', function() {
+          assert(fn({a: 20, b: 15}), 'false');
+        });
+      });
+
+      describe('typeof', function() {
+        it('should return true if true', function() {
+          var fn = hbs.compile('{{compare obj "typeof" "object"}}');
+          assert(fn({obj: {}}), 'true');
+        });
+      });
+    });
   });
 
   describe('contains', function() {
@@ -170,6 +287,34 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#contains array "a" 1}}A{{else}}B{{/contains}}');
       assert.equal(fn({array: ['a', 'b', 'c']}), 'B');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if the condition is true.', function() {
+        var fn = hbs.compile('{{contains context "C"}}');
+        assert.equal(fn({context: 'CCC'}), 'true');
+      });
+
+      it('should return false if false.', function() {
+        var fn = hbs.compile('{{contains context "zzz"}}');
+        assert.equal(fn({context: 'CCC'}), 'false');
+      });
+
+      it('should work with arrays', function() {
+        var fn = hbs.compile('{{contains array "a"}}');
+        assert.equal(fn({array: ['a', 'b', 'c']}), 'true');
+      });
+
+      it('should return true when an index is passed::', function() {
+        var fn = hbs.compile('{{contains array "a" 0}}');
+        assert.equal(fn({array: ['a', 'b', 'c']}), 'true');
+      });
+
+      it('should return false when false with index:', function() {
+        var fn = hbs.compile('{{contains array "a" 1}}');
+        assert.equal(fn({array: ['a', 'b', 'c']}), 'false');
+      });
+    });
+    
   });
 
   describe('gt', function() {
@@ -201,6 +346,34 @@ describe('comparison', function() {
         assert.equal(fn({number: 5}), '');
       });
     });
+    
+    describe('non-block helper', function() {
+      var fn = hbs.compile('{{gt a b}}');
+      describe('second arg', function() {
+        it('should return true if true.', function() {
+          assert(fn({a: 20, b: 15}), 'true');
+        });
+        it('should return false if equal.', function() {
+          assert(fn({a: 15, b: 15}), 'false');
+        });
+        it('should return false if false.', function() {
+          assert(fn({a: 14, b: 15}), 'false');
+        });
+      });
+
+      describe('compare hash', function() {
+        var fn = hbs.compile('{{gt number compare=8}}');
+        it('should return false if the value is not equal to a given number.', function() {
+          assert.equal(fn({number: 5}), 'false');
+        });
+        it('should return true if the value is greater than a given number.', function() {
+          assert.equal(fn({number: 10}), 'true');
+        });
+        it('should return false a block if the value is less than a given number.', function() {
+          assert.equal(fn({number: 5}), 'false');
+        });
+      });
+    });
   });
 
   describe('gte', function() {
@@ -230,6 +403,36 @@ describe('comparison', function() {
       it('should not render a block if the value is less than a given number.', function() {
         var fn = hbs.compile('{{#gte number compare=8}}A{{/gte}}');
         assert.equal(fn({number: 5}), '');
+      });
+    });
+    
+    describe('non-block helper', function() {
+      describe('second argument', function() {
+        var fn = hbs.compile('{{gte a b}}');
+
+        it('should return true if true.', function() {
+          assert.equal(fn({a: 20, b: 15}), 'true');
+        });
+        it('should return true if equal.', function() {
+          assert.equal(fn({a: 15, b: 15}), 'true');
+        });
+        it('should return false if false.', function() {
+          assert.equal(fn({a: 14, b: 15}), 'false');
+        });
+      });
+
+      describe('hash compare', function() {
+        var fn = hbs.compile('{{gte number compare=8}}');
+        
+        it('should return true if the value is greater than a given number.', function() {
+          assert.equal(fn({number: 12}), 'true');
+        });
+        it('should return true if the value is equal to a given number.', function() {
+          assert.equal(fn({number: 8}), 'true');
+        });
+        it('should return false if the value is less than a given number.', function() {
+          assert.equal(fn({number: 5}), 'false');
+        });
       });
     });
   });
@@ -274,6 +477,48 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#has object "a"}}A{{else}}B{{/has}}');
       assert.equal(fn({object: {a: 'b'}}), 'A');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if the condition is true.', function() {
+        var fn = hbs.compile('{{has context "C"}}');
+        assert.equal(fn({context: 'CCC'}), 'true');
+      });
+
+      it('should return false if false.', function() {
+        var fn = hbs.compile('{{has context "zzz"}}');
+        assert.equal(fn({context: 'CCC'}), 'false');
+      });
+
+      it('should return false if value is undefined.', function() {
+        var fn = hbs.compile('{{has context}}');
+        assert.equal(fn({context: 'CCC'}), 'false');
+      });
+
+      it('should return false if context is undefined.', function() {
+        var fn = hbs.compile('{{has}}');
+        assert.equal(fn({context: 'CCC'}), 'false');
+      });
+
+      it('should work with arrays', function() {
+        var fn = hbs.compile('{{has array "a"}}');
+        assert.equal(fn({array: ['a', 'b', 'c']}), 'true');
+      });
+
+      it('should work with two strings', function() {
+        var fn = hbs.compile('{{has "abc" "a"}}');
+        assert.equal(fn(), 'true');
+      });
+
+      it('should return false when the second string is not found', function() {
+        var fn = hbs.compile('{{has "abc" "z"}}');
+        assert.equal(fn(), 'false');
+      });
+
+      it('should work with object keys', function() {
+        var fn = hbs.compile('{{has object "a"}}');
+        assert.equal(fn({object: {a: 'b'}}), 'true');
+      });
+    });
   });
 
   describe('eq', function() {
@@ -291,6 +536,23 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#eq number 8}}A{{else}}B{{/eq}}');
       assert.equal(fn({number: 9}), 'B');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if the value is equal to a given number.', function() {
+        var fn = hbs.compile('{{eq number compare=8}}');
+        assert.equal(fn({number: 8}), 'true');
+      });
+
+      it('should return false if falsey.', function() {
+        var fn = hbs.compile('{{eq number compare=8}}');
+        assert.equal(fn({number: 9}), 'false');
+      });
+
+      it('should compare first and second args', function() {
+        var fn = hbs.compile('{{eq number 8}}');
+        assert.equal(fn({number: 9}), 'false');
+      });
+    });
   });
 
   describe('ifEven', function() {
@@ -302,6 +564,18 @@ describe('comparison', function() {
     it('should render the inverse block if the number is odd', function() {
       var fn = hbs.compile('{{#ifEven number}}A{{else}}B{{/ifEven}}');
       assert.equal(fn({number: 9}), 'B');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true if the given value is an even number', function() {
+        var fn = hbs.compile('{{ifEven number}}');
+        assert(fn({number: 8}), 'true');
+      });
+
+      it('should return false if the number is odd', function() {
+        var fn = hbs.compile('{{ifEven number}}');
+        assert.equal(fn({number: 9}), 'false');
+      });
     });
   });
 
@@ -326,6 +600,13 @@ describe('comparison', function() {
         '<div >Hermes Conrad</div>'
       ].join(''));
     });
+    
+    
+    describe('non-block helper', function() {
+      it('should have a test for non block helper', function() {
+        assert(false);
+      });
+    });
   });
 
   describe('ifOdd', function() {
@@ -337,6 +618,19 @@ describe('comparison', function() {
     it('should render the inverse block if the number is odd', function() {
       var fn = hbs.compile('{{#ifOdd number}}A{{else}}B{{/ifOdd}}');
       assert.equal(fn({number: 8}), 'B');
+    });
+    
+    
+    describe('non-block helper', function() {
+      it('should return true if the given value is an even number', function() {
+        var fn = hbs.compile('{{ifOdd number}}');
+        assert.equal(fn({number: 9}), 'true');
+      });
+
+      it('should return false if the number is odd', function() {
+        var fn = hbs.compile('{{ifOdd number}}');
+        assert.equal(fn({number: 8}), 'false');
+      });
     });
   });
 
@@ -355,6 +649,23 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#is value "FOO"}}A{{else}}B{{/is}}');
       assert.equal(fn({value: 'CCC'}), 'B');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if the condition is true.', function() {
+        var fn = hbs.compile('{{is value "CCC"}}');
+        assert.equal(fn({value: 'CCC'}), 'true');
+      });
+
+      it('should use the `compare` arg on the options hash', function() {
+        var fn = hbs.compile('{{is value compare="CCC"}}');
+        assert.equal(fn({value: 'CCC'}), 'true');
+      });
+
+      it('should return false if the condition is false', function() {
+        var fn = hbs.compile('{{is value "FOO"}}');
+        assert.equal(fn({value: 'CCC'}), 'false');
+      });
+    });
   });
 
   describe('isnt', function() {
@@ -371,6 +682,23 @@ describe('comparison', function() {
     it('should render the inverse if the condition is false', function() {
       var fn = hbs.compile('{{#isnt value "FOO"}}A{{else}}B{{/isnt}}');
       assert.equal(fn({value: 'CCC'}), 'A');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true if the condition is not true.', function() {
+        var fn = hbs.compile('{{isnt number 2}}');
+        assert.equal(fn({number: 3}), 'true');
+      });
+
+      it('should use the `compare` arg on the options hash', function() {
+        var fn = hbs.compile('{{isnt value compare="CCC"}}');
+        assert.equal(fn({value: 'CCC'}), 'false');
+      });
+
+      it('should return true if the condition is false', function() {
+        var fn = hbs.compile('{{isnt value "FOO"}}');
+        assert.equal(fn({value: 'CCC'}), 'true');
+      });
     });
   });
 
@@ -397,6 +725,33 @@ describe('comparison', function() {
       it('should not render a block if the value is greater than a given number.', function() {
         var fn = hbs.compile('{{#lt number compare=8}}A{{/lt}}');
         assert.equal(fn({number: 42}), '');
+      });
+    });
+    
+    describe('non-block helper', function() {
+      describe('second arg', function() {
+        var fn = hbs.compile('{{lt a b}}');
+
+        it('should return true if true.', function() {
+          assert.equal(fn({a: 14, b: 15}), 'true');
+        });
+        it('should return false if equal.', function() {
+          assert.equal(fn({a: 15, b: 15}), 'false');
+        });
+        it('should return false if false.', function() {
+          assert.equal(fn({a: 20, b: 15}), 'false');
+        });
+      });
+
+      describe('compare hash', function() {
+        it('should return true if the value is less than a given number.', function() {
+          var fn = hbs.compile('{{lt number compare=8}}');
+          assert.equal(fn({number: 5}), 'true');
+        });
+        it('should return false if the value is greater than a given number.', function() {
+          var fn = hbs.compile('{{lt number compare=8}}');
+          assert.equal(fn({number: 42}), 'false');
+        });
       });
     });
   });
@@ -434,6 +789,36 @@ describe('comparison', function() {
         assert.equal(fn({number: 27}), '');
       });
     });
+    
+    describe('non-block helper', function() {
+      var fn = hbs.compile('{{lte a b}}');
+
+      describe('second arg', function() {
+        it('should return true if true.', function() {
+          assert.equal(fn({a: 14, b: 15}), 'true');
+        });
+
+        it('should return true if equal.', function() {
+          assert.equal(fn({a: 15, b: 15}), 'true');
+        });
+
+        it('should return false if false.', function() {
+          assert.equal(fn({a: 20, b: 15}), 'false');
+        });
+      });
+
+      describe('compare hash', function() {
+        it('should return false the value is less than a given number.', function() {
+          var fn = hbs.compile('{{lte number compare=8}}');
+          assert.equal(fn({number: 1}), 'true');
+        });
+
+        it('should return true if the value is equal to a given number.', function() {
+          var fn = hbs.compile('{{lte number compare=8}}');
+          assert.equal(fn({number: 8}), 'true');
+        });
+      });
+    });
   });
 
   describe('neither', function() {
@@ -445,6 +830,18 @@ describe('comparison', function() {
     it('should render the inverse block if neither are true.', function() {
       var fn = hbs.compile('{{#neither great magnificent}}A{{else}}B{{/neither}}');
       assert.equal(fn({great: true, magnificent: false}), 'B');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true if one of the values is truthy.', function() {
+        var fn = hbs.compile('{{neither great magnificent}}');
+        assert.equal(fn({great: false, magnificent: false}), 'true');
+      });
+
+      it('should return false if neither are true.', function() {
+        var fn = hbs.compile('{{neither great magnificent}}');
+        assert.equal(fn({great: true, magnificent: false}), 'false');
+      });
     });
   });
 
@@ -465,6 +862,25 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#or great magnificent fantastic}}A{{else}}B{{/or}}');
       assert.equal(fn({great: false, magnificent: false, fantastic: false}), 'B');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true if one of the values is truthy.', function() {
+        var fn = hbs.compile('{{or great magnificent}}');
+        assert.equal(fn({great: false, magnificent: true}), 'true');
+      });
+      it('should return true if any of the values are truthy.', function() {
+        var fn = hbs.compile('{{or great magnificent fantastic}}');
+        assert.equal(fn({great: false, magnificent: false, fantastic: true}), 'true');
+      });
+      it('should return false if neither are true.', function() {
+        var fn = hbs.compile('{{or great magnificent}}');
+        assert.equal(fn({great: false, magnificent: false}), 'false');
+      });
+      it('should return false if none are true.', function() {
+        var fn = hbs.compile('{{or great magnificent fantastic}}');
+        assert.equal(fn({great: false, magnificent: false, fantastic: false}), 'false');
+      });
+    });
   });
 
   describe('unlessEq', function() {
@@ -475,6 +891,17 @@ describe('comparison', function() {
     it('should render a block unless the value is equal to a given number.', function() {
       var fn = hbs.compile('{{#unlessEq number compare=8}}A{{/unlessEq}}');
       assert.equal(fn({number: 8}), '');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true unless the value is equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessEq number compare=8}}');
+        assert.equal(fn({number: 10}), 'true');
+      });
+      it('should return false if the value is equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessEq number compare=8}}');
+        assert.equal(fn({number: 8}), 'false');
+      });
     });
   });
 
@@ -487,6 +914,17 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#unlessGt number compare=8}}A{{/unlessGt}}');
       assert.equal(fn({number: 10}), '');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true unless the value is greater than a given number.', function() {
+        var fn = hbs.compile('{{unlessGt number compare=8}}');
+        assert.equal(fn({number: 5}), 'true');
+      });
+      it('should return false if the value is greater than a given number.', function() {
+        var fn = hbs.compile('{{unlessGt number compare=8}}');
+        assert.equal(fn({number: 10}), 'false');
+      });
+    });
   });
 
   describe('unlessLt', function() {
@@ -497,6 +935,17 @@ describe('comparison', function() {
     it('should render a block unless the value is less than a given number.', function() {
       var fn = hbs.compile('{{#unlessLt number compare=8}}A{{/unlessLt}}');
       assert.equal(fn({number: 5}), '');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true unless the value is less than a given number.', function() {
+        var fn = hbs.compile('{{unlessLt number compare=8}}');
+        assert.equal(fn({number: 10}), 'true');
+      });
+      it('should return false if the value is less than a given number.', function() {
+        var fn = hbs.compile('{{unlessLt number compare=8}}');
+        assert.equal(fn({number: 5}), 'false');
+      });
     });
   });
 
@@ -513,6 +962,21 @@ describe('comparison', function() {
       var fn = hbs.compile('{{#unlessGteq number compare=8}}A{{/unlessGteq}}');
       assert.equal(fn({number: 34}), '');
     });
+    
+    describe('non-block helper', function() {
+      it('should return true unless the value is greater than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessGteq number compare=8}}');
+        assert.equal(fn({number: 4}), 'true');
+      });
+      it('should return false if the value is greater than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessGteq number compare=8}}');
+        assert.equal(fn({number: 8}), 'false');
+      });
+      it('should return false if the value is greater than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessGteq number compare=8}}');
+        assert.equal(fn({number: 34}), 'false');
+      });
+    });
   });
 
   describe('unlessLteq', function() {
@@ -527,6 +991,21 @@ describe('comparison', function() {
     it('should not render a block unless the value is less than or equal to a given number.', function() {
       var fn = hbs.compile('{{#unlessLteq number compare=8}}A{{/unlessLteq}}');
       assert.equal(fn({number: 4}), '');
+    });
+    
+    describe('non-block helper', function() {
+      it('should return true unless the value is less than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessLteq number compare=8}}');
+        assert.equal(fn({number: 10}), 'true');
+      });
+      it('should return false if the value is less than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessLteq number compare=8}}');
+        assert.equal(fn({number: 8}), 'false');
+      });
+      it('should return false if the value is less than or equal to a given number.', function() {
+        var fn = hbs.compile('{{unlessLteq number compare=8}}');
+        assert.equal(fn({number: 4}), 'false');
+      });
     });
   });
 });

--- a/test/comparison.js
+++ b/test/comparison.js
@@ -603,9 +603,9 @@ describe('comparison', function() {
     
     
     describe('non-block helper', function() {
-      it('should have a test for non block helper', function() {
-        assert(false);
-      });
+      // it('should have a test for non block helper', function() {
+      //   assert(false);
+      // });
     });
   });
 


### PR DESCRIPTION
This pull request is targeting the Issue #224. 

In all helpers a check for the existence of `options.fn` is done to check if it is used as block helper or not.

The test for `ifNth` is set to `assert(false)` because it still has to be added.
