### PR TITLE
Fix of the compare function

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -601,7 +601,7 @@ helpers.withSort = function(array, prop, options) {
   array.sort(function(a, b) {
     a = utils.get(a, prop);
     b = utils.get(b, prop);
-    return a > b;
+    return a > b ? 1 : (a < b ? -1 : 0);
   });
 
   if (utils.get(options, 'hash.reverse')) {


### PR DESCRIPTION
The previous version of the compare function was not consistent (it did not follow the requirements on the compare function), see https://tc39.github.io/ecma262/#sec-array.prototype.sort for details. You can see that the compare function is not correct by using it to sort larger arrays. For example, if you sort the letters of a well known sentence:
`"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a>b).join('')`
returns `"uge d ac  be e  f otjhmpsnooqrothrkliuvwxyz"` on Node.js 6.7.0. While `"the quick brown fox jumps over the lazy dog".split('').sort((a,b) => a > b ? 1 : (a < b ? -1 : 0)).join('')` returns the correct result `'        abcdeeefghhijklmnoooopqrrsttuuvwxyz'`.