### PR TITLE
add `.nl2br` string helper.

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('./utils');
+var hbs = require('handlebars');
 
 /**
  * Expose `helpers`
@@ -501,4 +502,26 @@ helpers.uppercase = function(str, options) {
     return options.fn(this).toUpperCase();
   }
   return '';
+};
+
+/**
+ * Inserts HTML line breaks before all newlines in string
+ *
+ * @name .nl2br
+ * @param {String} `str` The input string.
+ * @param {Object} `options` Handlebars options object
+ * @return {String} Inserted or Replaced
+ * @block
+ * @api public
+ */
+
+helpers.nl2br = function(str, options) {
+  if (!str || typeof str !== 'string') {
+      return str;
+  }
+  str = hbs.escapeExpression(str);
+  var breakTag = options.hash && options.hash.isXhtml ? '<br />' : '<br>';
+  var isReplace = options.hash && options.hash.replace ? true : false;
+  var nl2br = str.replace(/(\r\n|\n\r|\r|\n)/g, isReplace ? breakTag : breakTag + '$1');
+  return new hbs.SafeString(nl2br);
 };

--- a/test/string.js
+++ b/test/string.js
@@ -313,5 +313,30 @@ describe('string', function() {
       assert.equal(fn(), 'BENDER SHOULD NOT BE ALLOWED ON TV');
     });
   });
-});
 
+  describe('nl2br', function() {
+    it('should return an HTML line break inserted string', function() {
+      var context = {str: '<span>Line1.</span>\nLine2.\r\nLine3.\rLine4.\n\rLine5.'}
+      var fn = hbs.compile('{{nl2br str}}');
+      assert.equal(fn(context), '&lt;span&gt;Line1.&lt;/span&gt;<br>\nLine2.<br>\r\nLine3.<br>\rLine4.<br>\n\rLine5.');
+    });
+
+    it('should return an HTML line break replaced string', function() {
+      var context = {str: '<span>Line1.</span>\nLine2.\r\nLine3.\rLine4.\n\rLine5.'}
+      var fn = hbs.compile('{{nl2br str replace=true}}');
+      assert.equal(fn(context), '&lt;span&gt;Line1.&lt;/span&gt;<br>Line2.<br>Line3.<br>Line4.<br>Line5.');
+    });
+
+    it('should return an XHTML line break inserted string', function() {
+      var context = {str: 'Line1.\nLine2.\r\nLine3.\rLine4.\n\rLine5.'}
+      var fn = hbs.compile('{{nl2br str isXhtml=true}}');
+      assert.equal(fn(context), 'Line1.<br />\nLine2.<br />\r\nLine3.<br />\rLine4.<br />\n\rLine5.');
+    });
+
+    it('should return an XHTML line break replaced string', function() {
+      var context = {str: 'Line1.\nLine2.\r\nLine3.\rLine4.\n\rLine5.'}
+      var fn = hbs.compile('{{nl2br str isXhtml=true replace=true}}');
+      assert.equal(fn(context), 'Line1.<br />Line2.<br />Line3.<br />Line4.<br />Line5.');
+    });
+  });
+});


### PR DESCRIPTION
Add `.nl2br` string helper.
Also implemente unit tests.

`nl2br` helper is inserts HTML line breaks before all newlines in a string.