### PR TITLE
Make helpers work with empty strings

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -64,7 +64,7 @@ helpers.css = function(array, options) {
  */
 
 helpers.ellipsis = function(str, limit) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     if (str.length <= limit) {
       return str;
     }
@@ -140,7 +140,7 @@ helpers.sanitize = function(str) {
  */
 
 helpers.truncate = function(str, limit, suffix) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     var ch = typeof suffix === 'string' ? suffix : '';
     if (str.length > limit) {
       return html.sanitize(str).slice(0, limit - ch.length) + ch;

--- a/lib/string.js
+++ b/lib/string.js
@@ -41,7 +41,7 @@ helpers.camelcase = function(str) {
  */
 
 helpers.capitalize = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.charAt(0).toUpperCase()
       + str.slice(1);
   }
@@ -60,7 +60,7 @@ helpers.capitalize = function(str) {
  */
 
 helpers.capitalizeAll = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.replace(/\w\S*/g, function(word) {
       return exports.capitalize(word);
     });
@@ -77,7 +77,7 @@ helpers.capitalizeAll = function(str) {
  */
 
 helpers.center = function(str, spaces) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     var space = '';
     var i = 0;
     while (i < spaces) {
@@ -165,7 +165,7 @@ helpers.dotcase = function(str) {
  */
 
 helpers.hyphenate = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.split(' ').join('-');
   }
 };
@@ -199,7 +199,7 @@ helpers.isString = function(value) {
  */
 
 helpers.lowercase = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.toLowerCase();
   }
 };
@@ -219,7 +219,7 @@ helpers.lowercase = function(str) {
  */
 
 helpers.occurrences = function(str, substring) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     var len = substring.length;
     var pos = 0;
     var n = 0;
@@ -287,7 +287,7 @@ helpers.pathcase = function(str) {
  */
 
 helpers.plusify = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.split(' ').join('+');
   }
 };
@@ -306,7 +306,7 @@ helpers.plusify = function(str) {
  */
 
 helpers.reverse = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.split('').reverse().join('');
   }
 };
@@ -326,7 +326,7 @@ helpers.reverse = function(str) {
  */
 
 helpers.replace = function(str, a, b) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     if (!a || typeof a !== 'string') return str;
     if (!b || typeof b !== 'string') b = '';
     return str.split(a).join(b);
@@ -346,7 +346,7 @@ helpers.replace = function(str, a, b) {
  */
 
 helpers.sentence = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     var re = /((?:\S[^\.\?\!]*)[\.\?\!]*)/g;
     return str.replace(re, function(txt) {
       return txt.charAt(0).toUpperCase()
@@ -415,7 +415,7 @@ helpers.split = function(str, ch) {
 helpers.startsWith = function(prefix, str, options) {
   var args = [].slice.call(arguments);
   options = args.pop();
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     if (str.indexOf(prefix) === 0) {
       return options.fn(this);
     }
@@ -439,7 +439,7 @@ helpers.startsWith = function(prefix, str, options) {
  */
 
 helpers.titleize = function(str) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     var title = str.replace(/[ \-_]+/g, ' ');
     var words = title.match(/\w+/g);
     var len = words.length;
@@ -488,7 +488,7 @@ helpers.trim = function(str) {
  */
 
 helpers.uppercase = function(str, options) {
-  if (str && typeof str === 'string') {
+  if (typeof str === 'string') {
     return str.toUpperCase();
   } else {
     options = str;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -285,7 +285,7 @@ utils.identity = function(val) {
  */
 
 utils.isString = function(val) {
-  return val && typeof val === 'string';
+  return typeof val === 'string';
 };
 
 /**

--- a/test/html.js
+++ b/test/html.js
@@ -57,6 +57,10 @@ describe('html', function() {
       var fn = hbs.compile('{{ellipsis}}');
       fn().should.equal('');
     });
+    it('should return an empty string if empty', function() {
+      var fn = hbs.compile('{{ellipsis "" 1}}');
+      fn().should.equal('');
+    });
     it('should return then string truncated by a specified length.', function() {
       var fn = hbs.compile('{{ellipsis "Bender should not be allowed on tv." 31}}');
       fn().should.equal('Bender should not be allowed on…');
@@ -109,6 +113,10 @@ describe('html', function() {
   describe('truncate', function() {
     it('should return an empty string if undefined', function() {
       var fn = hbs.compile('{{truncate}}');
+      fn().should.equal('');
+    });
+    it('should return an empty string if empty', function() {
+      var fn = hbs.compile('{{truncate "" 1}}');
       fn().should.equal('');
     });
     it('should return the string truncated by a specified length.', function() {


### PR DESCRIPTION
In a project that uses `handlebars-helpers` both in views and application code, we ran into a few issues related to some assumptions (optimizations, maybe) re to empty string values. I was not sure this qualified as a valid pull-request until I found [this line](https://github.com/helpers/handlebars-helpers/blob/199a7c4d729e2b88e98998c8643038c608809f92/lib/utils/index.js#L288):

```javascript
utils.isString = function(val) {
  return val && typeof val === 'string';
};
```

Which is formally not true in JavaScript. An empty string `''` evaluates to boolean `false` but, is still a string. I do understand this can be an optimization in the context of Handlebars views but, can be confusing if the helpers get reused anywhere else. Some references:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean

This change makes helpers work with empty string values.