### PR TITLE
fix for passing in an abolute url to css helper

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -61,7 +61,12 @@ helpers.css = function(list, options) {
 
   return styles.map(function(item) {
     var ext = path.extname(item);
-    var fp = path.posix.join(assets, item);
+    var fp = item;
+
+    var isExternal =  /(^\/\/)|(:\/\/)/.test(item);
+    if(!isExternal) {
+      fp = path.posix.join(assets, item);
+    }
 
     if (ext === '.less') {
       return '<link type="text/css" rel="stylesheet/less" href="' + fp + '">';

--- a/lib/html.js
+++ b/lib/html.js
@@ -63,8 +63,7 @@ helpers.css = function(list, options) {
     var ext = path.extname(item);
     var fp = item;
 
-    var isExternal =  /(^\/\/)|(:\/\/)/.test(item);
-    if(!isExternal) {
+    if (!/(^\/\/)|(:\/\/)/.test(item)) {
       fp = path.posix.join(assets, item);
     }
 

--- a/test/html.js
+++ b/test/html.js
@@ -39,7 +39,7 @@ describe('html', function() {
     });
 
     it('should not use options.assets when passing in an absolute url', function() {
-      var actual = hbs.compile('{{{css "https://abc.com/bar.css"}}}')({options: {assets: "foo"}});
+      var actual = hbs.compile('{{{css "https://abc.com/bar.css"}}}')({options: {assets: 'foo'}});
       assert.equal(actual, '<link type="text/css" rel="stylesheet" href="https://abc.com/bar.css">');
     });
 

--- a/test/html.js
+++ b/test/html.js
@@ -38,6 +38,11 @@ describe('html', function() {
       assert.equal(actual, '<link type="text/css" rel="stylesheet" href="abc.css">');
     });
 
+    it('should not use options.assets when passing in an absolute url', function() {
+      var actual = hbs.compile('{{{css "https://abc.com/bar.css"}}}')({options: {assets: "foo"}});
+      assert.equal(actual, '<link type="text/css" rel="stylesheet" href="https://abc.com/bar.css">');
+    });
+
     it('should use the `href` attribute on the hash', function() {
       actual = hbs.compile('{{{css href=""}}}')();
       assert.equal(actual, '');


### PR DESCRIPTION
added a regex test to determine if path passed in is an absolute URL by checking for it either starting with // or containing :// 
If it is determined to be absolute url it skips adding the options.assets value to it

which fixes two potential problems
1. posix.path.join changes the value // to / so output href is incorrect
2. don't prepend the asset path to a URL that is absolute