### PR TITLE
Ellipsis documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2471,9 +2471,9 @@ Truncates a string to the specified `length`, and appends it with an elipsis, `�
 **Example**
 
 ```handlebars
-{{ellipsis (sanitize "<span>foo bar baz</span>"), 7}}
+{{ellipsis (sanitize "<span>foo bar baz</span>") 7}}
 <!-- results in:  'foo bar…' -->
-{{ellipsis "foo bar baz", 7}}
+{{ellipsis "foo bar baz" 7}}
 <!-- results in:  'foo bar…' -->
 ```
 


### PR DESCRIPTION
Example for ellipsis included a comma but it shouldn't