### PR TITLE
safer phoneNumber Helper

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -71,8 +71,14 @@ helpers.addCommas = function(num) {
  * @api public
  */
 
-helpers.phoneNumber = function(num) {
-  num = num.toString();
+helpers.phoneNumber = function(value) {
+  var num = value.toString().replace(/\D+/, '');
+
+  // format only the numbers you can format.
+  // If it's not going to work, don't do it.
+  if (num === '' || num.length !== 10) {
+    return value;
+  }
 
   return '(' + num.substr(0, 3) + ') '
     + num.substr(3, 3) + '-'


### PR DESCRIPTION
if value given to `phoneNumber` helper is not phone number, pre formatted number or something other than a phone number formatted value looks bad.

With this change, if output is not going to match `(xxx) xxx-xxxx` it simply won't do it.

this is to prevent things like
- `() -`
- `(N/A) -`
- `(som) e o-ther`

kind of values.