### PR TITLE
Remove is-even lib from dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,6 @@
     "helper-markdown": "^1.0.0",
     "helper-md": "^0.2.2",
     "html-tag": "^2.0.0",
-    "is-even": "^1.0.0",
     "is-glob": "^4.0.0",
     "is-number": "^4.0.0",
     "kind-of": "^6.0.0",

--- a/lib/comparison.js
+++ b/lib/comparison.js
@@ -308,7 +308,7 @@ helpers.isTruthy = function(val, options) {
  */
 
 helpers.ifEven = function(num, options) {
-  return util.value(utils.isEven(num), this, options);
+  return util.value((num % 2) === 0, this, options);
 };
 
 /**
@@ -348,7 +348,7 @@ helpers.ifNth = function(a, b, options) {
  */
 
 helpers.ifOdd = function(val, options) {
-  return util.value(!utils.isEven(val), this, options);
+  return util.value((val % 2) !== 0, this, options);
 };
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -21,7 +21,6 @@ require('micromatch', 'mm');
 require('falsey');
 
 // Number utils
-require('is-even');
 require('is-number');
 
 // Object utils

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "helper-markdown": "^1.0.0",
     "helper-md": "^0.2.2",
     "html-tag": "^2.0.0",
-    "is-even": "^1.0.0",
     "is-glob": "^4.0.0",
     "is-number": "^4.0.0",
     "kind-of": "^6.0.0",


### PR DESCRIPTION
`is-even` library is really worthless. Moreover, it's just a wrapper around `is-odd` library :) So I removed this library from dependencies and write the native implementation.