### PR TITLE
Test array helper "reverse"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ node_js:
   - '5'
   - '4'
   - '0.12'
-before_script:
-  - npm install -g gulp-cli
-script: gulp
+allowed_failures:
+  node_js: '0.12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,13 @@
 environment:
   matrix:
     # node.js
+    - nodejs_version: "9.0"
     - nodejs_version: "8.0"
     - nodejs_version: "7.0"
     - nodejs_version: "6.0"
     - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -13,15 +16,12 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm install
-  - npm install -g gulp-cli
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
-  # run tests
-  - gulp
 
 # Don't actually build.
 build: off

--- a/test/array.js
+++ b/test/array.js
@@ -4,8 +4,8 @@ require('mocha');
 var assert = require('assert');
 var hbs = require('handlebars').create();
 var helpers = require('..');
-helpers.array({handlebars: hbs});
 helpers.string({handlebars: hbs});
+helpers.array({handlebars: hbs});
 
 var context = {array: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'], duplicate: [ 'a', 'b', 'b', 'c', 'd', 'b', 'f', 'a', 'g']};
 
@@ -302,6 +302,32 @@ describe('array', function() {
       var ctx = {array: [{a: 'x'}, {a: 'y'}, {a: 'z'}]};
       var fn = hbs.compile('{{pluck array "a"}}');
       assert.equal(fn(ctx), 'x,y,z');
+    });
+  });
+
+  describe('reverse', function() {
+    it('should return an empty array when given an empty array', function() {
+      var locals = {array: []};
+      var fn = hbs.compile('{{reverse array}}');
+      assert.equal(fn(locals), []);
+    });
+
+    it('should return the same for arrays of lenght 1', function() {
+      var locals = {array: ['a']};
+      var fn = hbs.compile('{{reverse array}}');
+      assert.equal(fn(locals), ['a']);
+    });
+
+    it('should swap the items in an array of length 2', function() {
+      var locals = {array: ['a', 'b']};
+      var fn = hbs.compile('{{reverse array}}');
+      assert.equal(fn(locals), ['b', 'a']);
+    });
+
+    it('should revert arrays of arbitrary length', function() {
+      var clone = context.array.slice(0);
+      var fn = hbs.compile('{{reverse array}}');
+      assert.equal(fn(context), clone.reverse());
     });
   });
 


### PR DESCRIPTION
FYI: the change at the start of the test file ensures the `reverse` function for arrays is used rather then the one for strings. It works, but I'm not sure if this is the best solution 🤔 