### PR TITLE
Revise includeCount parameter value type

### DIFF
--- a/lib/inflection.js
+++ b/lib/inflection.js
@@ -22,7 +22,7 @@ var helpers = module.exports;
  * @param {Number} `count`
  * @param {String} `singular` The singular form
  * @param {String} `plural` The plural form
- * @param {String} `includeCount`
+ * @param {Boolean} `includeCount` Defaults to false
  * @return {String}
  * @api public
  */


### PR DESCRIPTION
This revises 
@param {String} `includeCount` to be @param {Boolean} `includeCount`, since the 'includeCount` parameter should only take either true or false. 
Include note that the `includeCount` parameter defaults to false if not included.