### PR TITLE
Handel undefined parameters in Array library helpers

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -75,6 +75,7 @@ helpers.before = function(array, n) {
  */
 
 helpers.eachIndex = function(array, options) {
+  if (!Array.isArray(array)) return '';
   var result = '';
   for (var i = 0; i < array.length; i++) {
     result += options.fn({item: array[i], index: i});
@@ -100,6 +101,7 @@ helpers.eachIndex = function(array, options) {
  */
 
 helpers.filter = function(array, value, options) {
+  if (!Array.isArray(array)) array = [];
   var content = '';
   var results = [];
 
@@ -182,6 +184,7 @@ helpers.first = function(array, n) {
  */
 
 helpers.forEach = function(array, options) {
+  if (!Array.isArray(array)) return '';
   var data = utils.createFrame(options, options.hash);
   var len = array.length;
   var buffer = '';


### PR DESCRIPTION
Array helpers.forEach was causing errors that resulted in status 500 errors in runtime when passed undefined or null values. Added `if (!Array.isArray(array)) return '';`  as a fast-fail measure to it and other Array helpers to handle bad parameters without causing errors. This fast-fail was already being used on multiple other helpers in this file, and was copied and added to those which might error without it. Added `if (!Array.isArray(array)) array = [];` to helpers.filter which should produce the similar safe result as the fast-fail.