### PR TITLE
reverse function removed from string (try to solve reverse functions problem)

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -489,10 +489,11 @@ helpers.replaceFirst = function(str, a, b) {
  * @api public
  */
 
-helpers.reverse = function(str) {
-  if (!util.isString(str)) return '';
-  return str.split('').reverse().join('');
-};
+// this function is already define in array functions
+// helpers.reverse = function(str) {
+//   if (!util.isString(str)) return '';
+//   return str.split('').reverse().join('');
+// };
 
 /**
  * Sentence case the given string


### PR DESCRIPTION
reverse function removed form string because it's overwrite revers function of array
in array reverse function is defined which is used for both string reverse and array reverse so we don't need string revers function because it make problem. it's overwrite array's revers function so when we use reverse function it always call string reverse function and it can't revers array.
String's reverse function
https://github.com/helpers/handlebars-helpers/blob/5d3405f178a9ec4c90df3c7dc07b4faf9a09dfd7/lib/string.js#L492
`helpers.reverse = function(str) {
  if (!util.isString(str)) return '';
  return str.split('').reverse().join('');
};
`
Array's reverse function 
https://github.com/helpers/handlebars-helpers/blob/5d3405f178a9ec4c90df3c7dc07b4faf9a09dfd7/lib/array.js#L473
`
helpers.reverse = function(val) {
  if (Array.isArray(val)) {
    val.reverse();
    return val;
  }
  if (val && typeof val === 'string') {
    return val.split('').reverse().join('');
  }
};
`