### PR TITLE
to fix truncateWords function not work properly

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -717,7 +717,7 @@ helpers.truncateWords = function(str, count, suffix) {
 
     var num = Number(count);
     var arr = str.split(/[ \t]/);
-    if (num > arr.length) {
+    if (num < arr.length) {
       arr = arr.slice(0, num);
     }
 


### PR DESCRIPTION
In String's truncateWords function there is a one mistake of > instead of < in if condition, That's why trucateWords not work properly

`if(num > arr.length)` => **This will not work properly**
This will slice array if word count is greater than total number of words, which is wrong

instead,

`if(num < arr.lenght)` => **this will work properly**
This will slice array if word count is less than total number of words, which is right

and now trucateWords work properly