### PR TITLE
Additional phone number support/cleanup

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -71,12 +71,23 @@ helpers.addCommas = function(num) {
  * @api public
  */
 
-helpers.phoneNumber = function(num) {
-  num = num.toString();
+ helpers.phoneNumber = function(value) {
+  var num = value.toString().replace(/\D+/g, '');
+  var prefix = '';
 
-  return '(' + num.substr(0, 3) + ') '
-    + num.substr(3, 3) + '-'
-    + num.substr(6, 4);
+  // format only the numbers you can format.
+  // If it's not going to work, don't do it.
+  if (num === '' || !(num.length == 10 || num.length == 11)) {
+    return value;
+  }
+  else if(num.length == 11 && num.substr(0,1) == '1'){
+    prefix = '1 ';
+    num = num.substr(1);
+  }
+
+  return prefix + '(' + num.substr(0,3) + ') '
+    + num.substr(3,3) + '-'
+    + num.substr(6,4);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "Stephen Way (http://stephenway.net)",
     "Thomas Jaggi (http://responsive.ch)",
     "Tim Douglas (https://github.com/timdouglas)",
+    "Will Berger (https://github.com/willzzzzzzzz)",
     "(https://github.com/homersimpsons)"
   ],
   "repository": "helpers/handlebars-helpers",

--- a/test/number.js
+++ b/test/number.js
@@ -28,9 +28,16 @@ describe('number', function() {
   });
 
   describe('phoneNumber', function() {
-    it('Format a phone number.', function() {
-      var fn = hbs.compile('{{phoneNumber value}}');
-      assert.equal(fn({value: '8005551212'}), '(800) 555-1212');
+    it('should return formatted number if 10-11 numeric digits', function () {
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '8005551212' }), '(800) 555-1212');
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '800.555.1212' }), '(800) 555-1212');
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '18005551212' }), '1 (800) 555-1212');
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '1-800-555-1212' }), '1 (800) 555-1212');
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '+18005551212' }), '1 (800) 555-1212');
+    });
+    it('should return original value if not 10-11 numeric digits', function () {
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: '800555121' }), '800555121');
+      assert.equal(hbs.compile('{{phoneNumber value}}')({ value: 'foo' }), 'foo');
     });
   });
 


### PR DESCRIPTION
Adding additional support for 11 digit phone numbers and no longer returning bad formatting when improper data sent to function. This code was built on changes serkanyersen originally suggested in 2018