### PR TITLE
updates micromatch version number

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -5,6 +5,7 @@ var path = require('path');
 var util = require('handlebars-utils');
 var utils = require('./utils');
 var number = require('./number');
+var micromatch = require('micromatch');
 var helpers = module.exports;
 
 /**
@@ -56,7 +57,7 @@ helpers.readdir = function(dir, filter) {
     });
   }
   if (utils.isGlob(filter)) {
-    return files.filter(utils.mm.matcher(filter));
+    return files.filter((file) => micromatch.isMatch(file, filter));
   }
   if (['isFile', 'isDirectory'].indexOf(filter) !== -1) {
     return files.filter(function(fp) {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "kind-of": "^6.0.0",
     "lazy-cache": "^2.0.2",
     "logging-helpers": "^1.0.0",
-    "micromatch": "^3.1.4",
+    "micromatch": "^4.0.5",
     "relative": "^3.0.2",
     "striptags": "^3.1.0",
     "to-gfm-code-block": "^0.1.1",


### PR DESCRIPTION
This PR addresses Snyk identified security vulnerabilities from an older version of micromatch.

[I have a PR open with helper-md](https://github.com/helpers/helper-md/pull/7) and another one with [helper-markdown](https://github.com/helpers/helper-markdown/pull/21) that once merged could be included in either this or a later PR that addresses security vulnerabilities found there (and thus here) as well.

These vulnerabilities were found through an internal tool called "[Snyk](https://snyk.io/)". You can see the vulnerability reports below. Basically the issue is that you need to upgrade your version of micromatch (and then once helper-md updates their code, updating your version of helper-md will address the other concerns).

![image](https://github.com/helpers/handlebars-helpers/assets/8006971/974faca0-c76a-4719-af5a-725622b995ef)
![image](https://github.com/helpers/handlebars-helpers/assets/8006971/ed0217e6-ade7-42f2-9a5a-057c4c3f6bc8)
![image](https://github.com/helpers/handlebars-helpers/assets/8006971/5735ab52-7954-42cd-95d4-4d024cb0dac2)
![image](https://github.com/helpers/handlebars-helpers/assets/8006971/6455cf60-d4d3-4e33-8aad-763b1d4233ef)
![image](https://github.com/helpers/handlebars-helpers/assets/8006971/37494873-b905-4548-bbd1-860ef843aa18)
